### PR TITLE
wall time and cost

### DIFF
--- a/src/agentopt/model_selection/base.py
+++ b/src/agentopt/model_selection/base.py
@@ -87,7 +87,10 @@ class SelectionResults(BaseModel):
 
     results: List[ModelResult] = Field(default_factory=list)
     selection_wall_time_seconds: Optional[float] = None
-    selection_cost: Optional[float] = None
+    selection_cost: Optional[float] = Field(
+        default=None,
+        description="Total selection cost in USD.",
+    )
 
     def __iter__(self):
         return iter(self.results)


### PR DESCRIPTION
# Summary
Track wall-clock time and actual API cost of the model selection process on SelectionResults
Cached (reused) responses are excluded from cost calculation — only fresh API calls count
Wall-clock time naturally reflects savings from parallel execution
Both metrics are displayed in the summary table output

# Test plan
 All 45 existing tests pass
 Run a selection with warm cache and verify selection_cost drops to ~$0 while per-combo prices remain unchanged
 Run with parallel=True and confirm selection_wall_time_seconds reflects actual elapsed time (not sum of sequential times)