### PR TITLE
Rename PyPI package to agentopt-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/agentopt/"><img src="https://img.shields.io/pypi/v/agentopt?logo=python&logoColor=white&color=3776ab" alt="PyPI"></a>
-  <!-- <a href="https://pepy.tech/projects/agentopt"><img src="https://static.pepy.tech/badge/agentopt" alt="Downloads"></a> -->
+  <a href="https://pypi.org/project/agentopt-py/"><img src="https://img.shields.io/pypi/v/agentopt-py?logo=python&logoColor=white&color=3776ab" alt="PyPI"></a>
+  <!-- <a href="https://pepy.tech/projects/agentopt-py"><img src="https://static.pepy.tech/badge/agentopt-py" alt="Downloads"></a> -->
   <!-- <a href="https://github.com/AgentOptimizer/agentopt"><img src="https://img.shields.io/github/stars/AgentOptimizer/agentopt?style=flat&logo=github&color=181717" alt="GitHub stars"></a> -->
   <a href="https://github.com/AgentOptimizer/agentopt/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-green?style=flat" alt="License"></a>
   <a href="https://agentoptimizer.github.io/agentopt/"><img src="https://img.shields.io/badge/docs-website-blue?style=flat&logo=materialformkdocs&logoColor=white" alt="Docs"></a>
@@ -44,7 +44,7 @@ Read more in our [blog post](https://agentoptimizer.github.io/agentopt/blog/2026
 ## Installation
 
 ```bash
-pip install agentopt
+pip install agentopt-py
 ```
 ## Quick Start
 
@@ -177,7 +177,7 @@ If you do not need the strict best model combination and want **more evaluation 
 | `"epsilon_lucb"` | Extra cost savings when ε-optimal is enough | Bandit; stops when an epsilon-optimal best arm is identified |
 | `"threshold"` | Thresholding objectives | Bandit; determines whether each combination is above/below a user-defined `threshold` on the performance metric (e.g., mean accuracy) |
 | `"lm_proposal"` | LLM-guided search | Uses a proposer LLM to shortlist promising combinations |
-| `"bayesian"` | Expensive evaluations | GP-based Bayesian optimization over categorical model choices; uses correlation between combinations (requires `pip install "agentopt[bayesian]"`) |
+| `"bayesian"` | Expensive evaluations | GP-based Bayesian optimization over categorical model choices; uses correlation between combinations (requires `pip install "agentopt-py[bayesian]"`) |
 
 ```python
 selector = ModelSelector(

--- a/docs/blog/posts/technical-deep-dive.md
+++ b/docs/blog/posts/technical-deep-dive.md
@@ -194,7 +194,7 @@ For every benchmark, there exists a combination within 3-5% of the best accuracy
 ## Get Started
 
 ```bash
-pip install agentopt
+pip install agentopt-py
 ```
 
 ```python

--- a/docs/concepts/algorithms.md
+++ b/docs/concepts/algorithms.md
@@ -188,7 +188,7 @@ selector = BayesianOptimizationModelSelector(
 !!! note "Extra dependency"
     Requires PyTorch and BoTorch:
     ```bash
-    pip install "agentopt[bayesian]"
+    pip install "agentopt-py[bayesian]"
     ```
 
 !!! success "When to use"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@
 === "pip"
 
     ```bash
-    pip install agentopt
+    pip install agentopt-py
     ```
 
 === "uv"
@@ -21,13 +21,13 @@
     Requires PyTorch and BoTorch:
 
     ```bash
-    pip install "agentopt[bayesian]"
+    pip install "agentopt-py[bayesian]"
     ```
 
 === "All Extras"
 
     ```bash
-    pip install "agentopt[bayesian]"
+    pip install "agentopt-py[bayesian]"
     ```
 
 ## Development Setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,7 +181,7 @@ AgentOpt patches `httpx` at the transport level — the same HTTP library used b
     ---
 
     ```bash
-    pip install agentopt
+    pip install agentopt-py
     ```
 
     [:octicons-arrow-right-24: Installation guide](getting-started/installation.md)

--- a/examples/advanced_selection_example.py
+++ b/examples/advanced_selection_example.py
@@ -8,9 +8,9 @@ method="auto" automatically finds the best combination (wired to arm_elimination
 strong best-arm identification with lower evaluation cost than brute_force).
 
 Prerequisites:
-    1. pip install openai agentopt
+    1. pip install openai agentopt-py
     2. Set OPENAI_API_KEY environment variable
-    3. For Bayesian optimization: pip install "agentopt[bayesian]"
+    3. For Bayesian optimization: pip install "agentopt-py[bayesian]"
 """
 
 from dotenv import load_dotenv

--- a/examples/ag2_example.py
+++ b/examples/ag2_example.py
@@ -2,7 +2,7 @@
 Example: AG2 agent with agentopt.
 
 Prerequisites:
-    1. pip install ag2 agentopt
+    1. pip install ag2 agentopt-py
     2. Set OPENAI_API_KEY environment variable
 
 Note: AG2's run() API spawns a background thread which breaks context

--- a/examples/crewai_example.py
+++ b/examples/crewai_example.py
@@ -2,7 +2,7 @@
 Example: CrewAI agent with agentopt.
 
 Prerequisites:
-    1. pip install crewai agentopt
+    1. pip install crewai agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/examples/custom_agent_example.py
+++ b/examples/custom_agent_example.py
@@ -5,7 +5,7 @@ This example shows how to use agentopt with a plain Python agent
 that makes OpenAI SDK calls directly. No framework needed.
 
 Prerequisites:
-    1. pip install openai agentopt
+    1. pip install openai agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -2,7 +2,7 @@
 Example: LangChain agent with agentopt.
 
 Prerequisites:
-    1. pip install langchain-classic langchain-openai agentopt
+    1. pip install langchain-classic langchain-openai agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/examples/langgraph_example.py
+++ b/examples/langgraph_example.py
@@ -2,7 +2,7 @@
 Example: LangGraph agent with agentopt.
 
 Prerequisites:
-    1. pip install langchain-openai langgraph agentopt
+    1. pip install langchain-openai langgraph agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/examples/llamaindex_example.py
+++ b/examples/llamaindex_example.py
@@ -2,7 +2,7 @@
 Example: LlamaIndex agent with agentopt.
 
 Prerequisites:
-    1. pip install llama-index-core llama-index-llms-openai agentopt
+    1. pip install llama-index-core llama-index-llms-openai agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/examples/openai_sdk_example.py
+++ b/examples/openai_sdk_example.py
@@ -2,7 +2,7 @@
 Example: OpenAI Agents SDK agent with agentopt.
 
 Prerequisites:
-    1. pip install openai-agents agentopt
+    1. pip install openai-agents agentopt-py
     2. Set OPENAI_API_KEY environment variable
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.22"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agentopt"
+name = "agentopt-py"
 version = "0.1.0"
 description = "Find the right LLM models for your AI agents — automatic model selection with accuracy/cost/latency tradeoffs"
 requires-python = ">=3.10"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 readme = "README.md"
 authors = [
     { name = "AgentOptimizer Team" },

--- a/src/agentopt/__init__.py
+++ b/src/agentopt/__init__.py
@@ -76,7 +76,7 @@ def ModelSelector(
         if method == "bayesian":
             raise ImportError(
                 "Bayesian optimization requires optional dependencies: "
-                'install with `pip install "agentopt[bayesian]"`'
+                'install with `pip install "agentopt-py[bayesian]"`'
             )
         raise ValueError(
             f"Unknown method {method!r}. " f"Choose from: {', '.join(_METHODS)}"

--- a/src/agentopt/model_selection/base.py
+++ b/src/agentopt/model_selection/base.py
@@ -541,7 +541,7 @@ class SelectionResults(BaseModel):
 
         Subplots: Accuracy vs Latency, Accuracy vs Price.
 
-        Requires ``matplotlib`` (install with ``pip install agentopt[plot]``).
+        Requires ``matplotlib`` (install with ``pip install agentopt-py[plot]``).
         If *path* is given the figure is saved to that file, otherwise
         ``plt.show()`` is called.
         """
@@ -550,7 +550,7 @@ class SelectionResults(BaseModel):
         except ImportError:
             raise ImportError(
                 "matplotlib is required for plot_pareto. "
-                "Install it with: pip install agentopt[plot]"
+                "Install it with: pip install agentopt-py[plot]"
             )
 
         # Deduplicate (same logic as __str__).

--- a/src/agentopt/model_selection/bayesian_optimization.py
+++ b/src/agentopt/model_selection/bayesian_optimization.py
@@ -25,7 +25,7 @@ def _require_botorch() -> None:
     except ImportError as e:
         raise ImportError(
             "Bayesian optimization requires optional dependencies: "
-            """Install with `pip install "agentopt[bayesian]"`"""
+            """Install with `pip install "agentopt-py[bayesian]"`"""
         ) from e
 
 


### PR DESCRIPTION
## Summary

- Rename PyPI package from `agentopt` to `agentopt-py` (PyPI rejects `agentopt` as too similar to existing `agent-opt` by Future AGI)
- Update all `pip install` references across README, docs, examples, and source code
- Update PyPI badge URL
- Import name remains `import agentopt`

## Test plan

- [ ] `python3 -m build` succeeds
- [ ] `twine check dist/*` passes
- [ ] Upload to PyPI succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)