### PR TITLE
Fix dark mode text visibility and remove inaccurate blog section

### DIFF
--- a/docs/blog/posts/technical-deep-dive.md
+++ b/docs/blog/posts/technical-deep-dive.md
@@ -181,10 +181,6 @@ We validated AgentOpt across four diverse benchmarks using 9 models on Amazon Be
 
 Arm Elimination is the consistent winner: it achieves near-brute-force accuracy across all four benchmarks while using 40-60% less budget. LM Proposal (asking GPT-4.1 to predict the best combo) matches brute force on GPQA (where the answer is intuitive) but collapses to 34% on HotpotQA and 45% on BFCL. It can't predict that Ministral outperforms Opus as a planner.
 
-### Budget Alternatives
-
-As shown in the cost-savings table above, for every benchmark there exists a combination within 3-5% of the best accuracy that costs 10-100x less. You don't need the most expensive model to get near-optimal results.
-
 ## Get Started
 
 ```bash

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -10,7 +10,7 @@
   --ao-border-hover: rgba(255, 255, 255, 0.13);
   --ao-text: #edede9;
   --ao-text-secondary: #9a9a95;
-  --ao-text-muted: #3a3a37;
+  --ao-text-muted: #9a9a95;
   --ao-accent: #9f98f0;
   --ao-accent-dim: rgba(159, 152, 240, 0.15);
   --ao-teal: #5dcaa5;


### PR DESCRIPTION
Fix nearly invisible muted text in dark mode by changing --ao-text-muted from #3a3a37 to #9a9a95. 