### PR TITLE
Add streaming random search model selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If you do not need the strict best model combination and want **more evaluation 
 | `"auto"` (default) | General use | Automatically finds the best combination (wired to `arm_elimination` — strong best-arm identification with lower evaluation cost than `brute_force`) |
 | `"brute_force"` | Small search spaces | Evaluates all combinations |
 | `"random"` | Quick exploration | Samples a random fraction |
+| `"streaming_random"` | Streaming / online updates | Samples once, then incrementally updates the sampled combos on new batches |
 | `"hill_climbing"` | Topology-aware search | Greedy search using model quality/speed rankings |
 | `"arm_elimination"` | Best-arm identification | Bandit; eliminates statistically dominated combinations |
 | `"epsilon_lucb"` | Extra cost savings when ε-optimal is enough | Bandit; stops when an epsilon-optimal best arm is identified |

--- a/docs/api/selectors.md
+++ b/docs/api/selectors.md
@@ -41,6 +41,11 @@ Returns a [`SelectionResults`](results.md) object.
       members: false
       show_bases: false
 
+::: agentopt.model_selection.streaming_random_search.StreamingRandomSearchModelSelector
+    options:
+      members: false
+      show_bases: false
+
 ::: agentopt.model_selection.hill_climbing.HillClimbingModelSelector
     options:
       members: false

--- a/docs/concepts/algorithms.md
+++ b/docs/concepts/algorithms.md
@@ -1,6 +1,6 @@
 # Selection Algorithms
 
-AgentOpt provides 8 selection algorithms. Choose based on your search space size and evaluation budget.
+AgentOpt provides 9 selection algorithms. Choose based on your search space size and evaluation budget.
 
 ## At a Glance
 
@@ -8,6 +8,7 @@ AgentOpt provides 8 selection algorithms. Choose based on your search space size
 |:----------|:---------|:------------|:---------|
 | [Brute Force](#brute-force) | Exhaustive | All | Small spaces (< 50 combos) |
 | [Random Search](#random-search) | Sampling | Configurable fraction | Quick baselines |
+| [Streaming Random Search](#streaming-random-search) | Streaming sampling | Incremental | Online / incoming batches |
 | [Hill Climbing](#hill-climbing) | Greedy + restarts | Guided neighbors | Medium spaces |
 | [Arm Elimination](#arm-elimination) | Progressive pruning | Adaptive | Statistical early stopping |
 | [Epsilon LUCB](#epsilon-lucb) | ε-optimal LUCB | Adaptive | Cost savings when ε-optimal is enough |
@@ -77,6 +78,38 @@ selector = RandomSearchModelSelector(
 
 !!! success "When to use"
     Quick exploration to establish a baseline before committing to a thorough search.
+
+---
+
+## Streaming Random Search
+
+Samples a random subset once, then incrementally updates those sampled combinations as new batches arrive.
+
+```python
+from agentopt import StreamingRandomSearchModelSelector
+
+selector = StreamingRandomSearchModelSelector(
+    agent=MyAgent,
+    models=models,
+    eval_fn=eval_fn,
+    dataset=warm_start_dataset,  # seed batch
+    sample_fraction=0.25,
+    seed=42,
+)
+
+selector.select_best()           # evaluate warm start once
+selector.update(stream_batch_1)  # keep updating online
+selector.update(stream_batch_2)
+best_combo = selector.best_combo()
+```
+
+| Parameter | Default | Description |
+|:----------|:--------|:------------|
+| `sample_fraction` | `0.25` | Fraction of combinations sampled once and reused |
+| `seed` | `None` | Random seed for reproducible sampling |
+
+!!! success "When to use"
+    Streaming / online settings where data arrives over time and you want incremental updates instead of full reselection each round.
 
 ---
 

--- a/src/agentopt/__init__.py
+++ b/src/agentopt/__init__.py
@@ -21,6 +21,7 @@ from .model_selection import (
     DatapointResult,
     ModelResult,
     RandomSearchModelSelector,
+    StreamingRandomSearchModelSelector,
     SelectionResults,
     ThresholdBanditSEModelSelector,
 )
@@ -35,6 +36,7 @@ _METHODS = {
     "auto": ArmEliminationModelSelector,
     "brute_force": BruteForceModelSelector,
     "random": RandomSearchModelSelector,
+    "streaming_random": StreamingRandomSearchModelSelector,
     "hill_climbing": HillClimbingModelSelector,
     "arm_elimination": ArmEliminationModelSelector,
     "epsilon_lucb": EpsilonLUCBModelSelector,
@@ -64,6 +66,7 @@ def ModelSelector(
             ``"brute_force"``). Other options: ``"brute_force"``,
             ``"random"``, ``"hill_climbing"``, ``"arm_elimination"``,
             ``"epsilon_lucb"``, ``"threshold"``, ``"lm_proposal"``,
+            ``"streaming_random"``,
             ``"bayesian"``.
         **kwargs: Additional arguments passed to the selector
             (e.g. ``epsilon``, ``threshold``, ``sample_fraction``).
@@ -95,6 +98,7 @@ __all__ = [
     # Selectors
     "BruteForceModelSelector",
     "RandomSearchModelSelector",
+    "StreamingRandomSearchModelSelector",
     "HillClimbingModelSelector",
     "ArmEliminationModelSelector",
     "EpsilonLUCBModelSelector",

--- a/src/agentopt/model_selection/__init__.py
+++ b/src/agentopt/model_selection/__init__.py
@@ -7,6 +7,7 @@ from .epsilon_lucb import EpsilonLUCBModelSelector
 from .hill_climbing import HillClimbingModelSelector
 from .lm_proposal import LMProposalModelSelector
 from .random_search import RandomSearchModelSelector
+from .streaming_random_search import StreamingRandomSearchModelSelector
 from .threshold_successive_elimination import ThresholdBanditSEModelSelector
 
 # Bayesian is optional (requires torch/botorch)
@@ -24,6 +25,7 @@ __all__ = [
     "EpsilonLUCBModelSelector",
     "ThresholdBanditSEModelSelector",
     "LMProposalModelSelector",
+    "StreamingRandomSearchModelSelector",
     "BayesianOptimizationModelSelector",
     "DatapointResult",
     "ModelResult",

--- a/src/agentopt/model_selection/streaming_random_search.py
+++ b/src/agentopt/model_selection/streaming_random_search.py
@@ -1,0 +1,293 @@
+"""
+Streaming random-search model selection.
+
+Evaluates a fixed random subset of combinations on incoming data batches and
+keeps cumulative metrics updated over time.
+"""
+
+import asyncio
+import math
+import random
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..base_models import Dataset, EvalFn, ModelCandidate, validate_dataset
+from .base import BaseModelSelector, ModelResult, SelectionResults
+
+
+class StreamingRandomSearchModelSelector(BaseModelSelector):
+    """
+    Random-search selector that supports streaming updates.
+
+    A subset of combinations is sampled once at initialization and reused for
+    all incoming batches.
+    """
+
+    _CONVERGENCE_DELTA = 0.02
+    _CONVERGENCE_PATIENCE_BATCHES = 10
+
+    def __init__(
+        self,
+        agent: Any = None,
+        models: Dict[str, List[ModelCandidate]] = None,
+        eval_fn: EvalFn = None,
+        dataset: Dataset = None,
+        sample_fraction: float = 0.25,
+        seed: Optional[int] = None,
+        model_prices: Optional[Dict[str, Dict[str, float]]] = None,
+        tracker=None,
+    ) -> None:
+        super().__init__(
+            agent=agent,
+            models=models,
+            eval_fn=eval_fn,
+            dataset=dataset,
+            model_prices=model_prices,
+            tracker=tracker,
+        )
+        if not 0 < sample_fraction <= 1:
+            raise ValueError("sample_fraction must be in the range (0, 1].")
+
+        self.sample_fraction = sample_fraction
+        self.seed = seed
+
+        self._all_combos: List[Dict[str, ModelCandidate]] = self._all_combos()
+        total = len(self._all_combos)
+        sample_size = max(1, math.ceil(total * self.sample_fraction))
+        sample_size = min(sample_size, total)
+
+        if sample_size == total:
+            self._sampled_indices = list(range(total))
+        else:
+            rng = random.Random(self.seed)
+            self._sampled_indices = sorted(rng.sample(range(total), sample_size))
+        self._sampled_combos = [self._all_combos[i] for i in self._sampled_indices]
+
+        self._combo_scores: Dict[int, List[float]] = {
+            i: [] for i in range(len(self._sampled_combos))
+        }
+        self._combo_latencies: Dict[int, List[float]] = {
+            i: [] for i in range(len(self._sampled_combos))
+        }
+        self._combo_dp_ids: Dict[int, List[str]] = {
+            i: [] for i in range(len(self._sampled_combos))
+        }
+        self._seen_samples = 0
+        self._seed_consumed = False
+
+        self._converged = False
+        self._stable_batches = 0
+        self._best_combo_signature: Optional[Tuple[Tuple[str, str], ...]] = None
+        self._best_accuracy: Optional[float] = None
+
+    def _run_selection(
+        self, parallel: bool = False, max_concurrent: int = 20,
+    ) -> SelectionResults:
+        if not self._seed_consumed:
+            result = self.update(self.dataset, parallel=parallel, max_concurrent=max_concurrent)
+            self._seed_consumed = True
+            return result
+        return self.results()
+
+    def update(
+        self, batch: Dataset, parallel: bool = False, max_concurrent: int = 20,
+    ) -> SelectionResults:
+        """Evaluate sampled combinations on a new incoming batch."""
+        if self._converged:
+            print(
+                "\nStreaming random search converged; skipping new batch. "
+                "Current best combo is stable."
+            )
+            return self.results()
+
+        validate_dataset(batch)
+        if parallel:
+            asyncio.run(self._update_async(batch, max_concurrent=max_concurrent))
+        else:
+            self._update_sequential(batch)
+        self._seen_samples += len(batch)
+
+        results = self.results()
+        self._update_convergence_state(results)
+        return results
+
+    def update_one(
+        self,
+        input_data: Any,
+        expected_answer: Any,
+        parallel: bool = False,
+        max_concurrent: int = 20,
+    ) -> SelectionResults:
+        return self.update(
+            [(input_data, expected_answer)],
+            parallel=parallel,
+            max_concurrent=max_concurrent,
+        )
+
+    def results(self) -> SelectionResults:
+        all_results: List[ModelResult] = []
+        for idx, combo in enumerate(self._sampled_combos):
+            combo_name = self._combo_name(combo)
+            scores = self._combo_scores[idx]
+            latencies = self._combo_latencies[idx]
+            dp_ids = self._combo_dp_ids[idx]
+
+            if scores:
+                accuracy = sum(scores) / len(scores)
+                avg_latency = sum(latencies) / len(latencies)
+            else:
+                accuracy, avg_latency = 0.0, 0.0
+
+            input_tokens, output_tokens = self._fetch_tokens(combo_name)
+            dp_results = (
+                self._build_datapoint_results(scores, latencies, dp_ids) if dp_ids else []
+            )
+            all_results.append(
+                self._make_result(
+                    model_name=combo_name,
+                    accuracy=accuracy,
+                    latency_seconds=avg_latency,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    attribute="combination",
+                    is_best=False,
+                    datapoint_results=dp_results,
+                )
+            )
+
+        best_info = self._find_best(all_results)
+        if best_info is not None:
+            best_name, _ = best_info
+            for result in all_results:
+                if result.model_name == best_name:
+                    result.is_best = True
+                    break
+
+        return SelectionResults(results=all_results)
+
+    def best_combo(self) -> Optional[Dict[str, str]]:
+        return self.results().get_best_combo()
+
+    def has_converged(self) -> bool:
+        return self._converged
+
+    def should_continue(self) -> bool:
+        return not self._converged
+
+    def convergence_state(self) -> Dict[str, Any]:
+        return {
+            "converged": self._converged,
+            "stable_batches": self._stable_batches,
+            "required_stable_batches": self._CONVERGENCE_PATIENCE_BATCHES,
+            "delta": self._CONVERGENCE_DELTA,
+            "best_accuracy": self._best_accuracy,
+            "best_combo": dict(self._best_combo_signature)
+            if self._best_combo_signature is not None
+            else None,
+            "sampled_combinations": len(self._sampled_combos),
+            "sample_fraction": self.sample_fraction,
+        }
+
+    def _update_sequential(self, batch: Dataset) -> None:
+        dp_offset = self._seen_samples
+        total = len(self._sampled_combos)
+        print(
+            f"\nUpdating stream random-search (sequential): "
+            f"{total}/{len(self._all_combos)} combinations, batch={len(batch)}"
+        )
+
+        for idx, combo in enumerate(self._sampled_combos, 1):
+            combo_name = self._combo_name(combo)
+            print(f"  [{idx}/{total}] {combo_name}")
+            scores, latencies, dp_ids = self._evaluate_combo(
+                combo, batch, label=combo_name, dp_offset=dp_offset
+            )
+            self._combo_scores[idx - 1].extend(scores)
+            self._combo_latencies[idx - 1].extend(latencies)
+            self._combo_dp_ids[idx - 1].extend(dp_ids)
+
+    async def _update_async(self, batch: Dataset, max_concurrent: int) -> None:
+        dp_offset = self._seen_samples
+        batch_size = len(batch)
+        n_combo, dp_concurrent = self._compute_concurrency(max_concurrent, batch_size)
+        combo_sem = asyncio.Semaphore(n_combo)
+        total = len(self._sampled_combos)
+        print(
+            f"\nUpdating stream random-search (async): "
+            f"{total}/{len(self._all_combos)} combinations, batch={batch_size}, "
+            f"max {max_concurrent} total concurrent"
+        )
+
+        async def _eval_combo(
+            idx: int,
+            combo: Dict[str, ModelCandidate],
+        ) -> Tuple[int, List[float], List[float], List[str]]:
+            async with combo_sem:
+                combo_name = self._combo_name(combo)
+                scores, latencies, dp_ids = await self._evaluate_combo_async(
+                    combo,
+                    batch,
+                    label=combo_name,
+                    max_concurrent=dp_concurrent,
+                    dp_offset=dp_offset,
+                )
+                return idx, scores, latencies, dp_ids
+
+        results = await asyncio.gather(
+            *[
+                _eval_combo(idx, combo)
+                for idx, combo in enumerate(self._sampled_combos)
+            ],
+            return_exceptions=True,
+        )
+        for i, res in enumerate(results):
+            if isinstance(res, Exception):
+                combo_name = self._combo_name(self._sampled_combos[i])
+                print(f"  [{combo_name}] failed: {res}")
+                continue
+            idx, scores, latencies, dp_ids = res
+            self._combo_scores[idx].extend(scores)
+            self._combo_latencies[idx].extend(latencies)
+            self._combo_dp_ids[idx].extend(dp_ids)
+
+    @staticmethod
+    def _combo_signature(
+        combo: Optional[Dict[str, str]],
+    ) -> Optional[Tuple[Tuple[str, str], ...]]:
+        if combo is None:
+            return None
+        return tuple(sorted((str(k), str(v)) for k, v in combo.items()))
+
+    def _update_convergence_state(self, results: SelectionResults) -> None:
+        best = results.get_best()
+        if best is None:
+            return
+
+        combo_sig = self._combo_signature(results.get_best_combo())
+        if combo_sig is None:
+            return
+
+        current_acc = best.accuracy
+        if self._best_combo_signature is None or self._best_accuracy is None:
+            self._best_combo_signature = combo_sig
+            self._best_accuracy = current_acc
+            self._stable_batches = 0
+            return
+
+        combo_unchanged = combo_sig == self._best_combo_signature
+        improvement = current_acc - self._best_accuracy
+
+        if combo_unchanged and improvement < self._CONVERGENCE_DELTA:
+            self._stable_batches += 1
+        else:
+            self._stable_batches = 0
+
+        self._best_combo_signature = combo_sig
+        self._best_accuracy = current_acc
+
+        if self._stable_batches >= self._CONVERGENCE_PATIENCE_BATCHES:
+            self._converged = True
+            print(
+                "\nStreaming random search converged: best combo stable for "
+                f"{self._stable_batches} batches with < "
+                f"{self._CONVERGENCE_DELTA:.0%} accuracy improvement."
+            )

--- a/tests/test_streaming_random_search.py
+++ b/tests/test_streaming_random_search.py
@@ -1,0 +1,88 @@
+"""Unit tests for StreamingRandomSearchModelSelector."""
+
+from agentopt import ModelSelector, StreamingRandomSearchModelSelector
+
+
+class DummyAgent:
+    """Simple deterministic agent for selector tests."""
+
+    def __init__(self, models):
+        self.models = models
+
+    def run(self, _input_data):
+        return f"{self.models['planner']}|{self.models['solver']}"
+
+
+def exact_match(expected, actual):
+    return float(expected == actual)
+
+
+def test_streaming_random_sampling_size():
+    selector = StreamingRandomSearchModelSelector(
+        agent=DummyAgent,
+        models={
+            "planner": ["p1", "p2", "p3"],
+            "solver": ["s1", "s2"],
+        },
+        eval_fn=exact_match,
+        dataset=[({"q": "seed"}, "p1|s1")],
+        sample_fraction=0.5,
+        seed=7,
+    )
+    # 3 * 2 = 6 combos; sample_fraction=0.5 => ceil(3) = 3 sampled combos.
+    assert len(selector._sampled_combos) == 3
+    assert len(selector._all_combos) == 6
+
+
+def test_streaming_random_updates_best_combo_over_time():
+    selector = StreamingRandomSearchModelSelector(
+        agent=DummyAgent,
+        models={"planner": ["p1", "p2"], "solver": ["s1", "s2"]},
+        eval_fn=exact_match,
+        dataset=[({"q": "seed"}, "p1|s1")],
+        sample_fraction=1.0,
+        seed=3,
+    )
+
+    initial = selector.select_best()
+    assert initial.get_best_combo() == {"planner": "p1", "solver": "s1"}
+
+    # Stream in data that favors a different combination.
+    selector.update(
+        [
+            ({"q": "b1"}, "p2|s2"),
+            ({"q": "b2"}, "p2|s2"),
+            ({"q": "b3"}, "p2|s2"),
+        ]
+    )
+    best_after = selector.results().get_best_combo()
+    assert best_after == {"planner": "p2", "solver": "s2"}
+
+
+def test_streaming_random_converges_after_stable_batches():
+    selector = StreamingRandomSearchModelSelector(
+        agent=DummyAgent,
+        models={"planner": ["p1", "p2"], "solver": ["s1", "s2"]},
+        eval_fn=exact_match,
+        dataset=[({"q": "seed"}, "p2|s2")],
+        sample_fraction=1.0,
+        seed=11,
+    )
+
+    selector.select_best()
+    for _ in range(10):
+        selector.update_one({"q": "stream"}, "p2|s2")
+
+    assert selector.has_converged() is True
+    assert selector.should_continue() is False
+
+
+def test_model_selector_factory_supports_streaming_random():
+    selector = ModelSelector(
+        agent=DummyAgent,
+        models={"planner": ["p1"], "solver": ["s1"]},
+        eval_fn=exact_match,
+        dataset=[({"q": "seed"}, "p1|s1")],
+        method="streaming_random",
+    )
+    assert isinstance(selector, StreamingRandomSearchModelSelector)


### PR DESCRIPTION
(1) What this PR does: Adds a new `StreamingRandomSearchModelSelector` that samples model combinations once and then incrementally updates scores/latencies on incoming data batches, with factory wiring (`method="streaming_random"`), exports, docs, and unit tests.

(2) How to test results: Run `PYTHONPATH=src pytest -q tests/test_streaming_random_search.py tests/test_concurrency.py` and verify all tests pass.

(3) Which issue it resolves: Resolves #3 (model selection with streaming incoming data) by adding a streaming random-search selector alongside the existing streaming brute-force direction.