### PR TITLE
refactor proxy for cleanness

### DIFF
--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -115,36 +115,38 @@ Traffic on 59198 → combo A. Traffic on 59205 → combo B. No ambiguity, no heu
 
 Here's everything that happens end-to-end when you run an evaluation:
 
-**Startup**: `tracker.start()` launches a background thread running an asyncio event loop. No ports are bound yet.
+**Startup**: `tracker.start()` constructs the proxy server and installs the httpx monkey-patch. No ports are bound yet — listeners are per-session.
 
-**Session creation**: `tracker.track(data_id="dp_1", combo_id="gpt4o")` creates a session, opens a new TCP port for it, sets the ContextVar (for in-process), and returns session env vars (for subprocess).
+**Session creation**: `tracker.track(data_id="dp_1", combo_id="gpt4o")` creates a session, binds a new TCP port for it (each port gets its own listener thread), sets the ContextVar (for in-process), and returns session env vars (for subprocess).
 
 **In-process path**: The agent calls the OpenAI SDK → SDK calls `httpx.Client.send()` → the monkey-patch intercepts, reads the ContextVar to get the port, rewrites the URL to `http://localhost:{port}/path`, adds the `X-AgentOpt-Target` header → sends plaintext HTTP to the proxy → proxy reads the request, forwards to real OpenAI over HTTPS, records the response → returns response to the agent.
 
 **Subprocess path**: The agent runs as a child process with `HTTPS_PROXY` and `SSL_CERT_FILE` set → the agent's HTTP library connects to the proxy port and sends CONNECT → proxy responds 200 → agent starts TLS handshake → proxy impersonates the API server using a fake certificate signed by our CA → agent accepts (our CA is in its trust store via `SSL_CERT_FILE`) → agent sends the API request through the encrypted channel → proxy decrypts, reads, forwards to real API server over a separate HTTPS connection → gets response, records token counts and latency → re-encrypts and returns to agent.
 
-**Session teardown**: `track()` scope exits → ContextVar is reset, environment is restored, the session's TCP port is unbound, and all recorded calls are archived.
+**Session teardown**: `track()` scope exits → ContextVar is reset, the session's listener socket is closed (in-flight connection threads finish on their own and write into the archived session), and all recorded calls are archived.
 
-**Shutdown**: `tracker.stop()` restores the original `httpx.Client.send`, stops the event loop, and flushes the cache.
+**Shutdown**: `tracker.stop()` restores the original `httpx.Client.send`, closes any remaining listener sockets, and flushes the cache.
 
 ## Session lifecycle
 
 ```
 tracker.start()
-  └── ProxyServer starts (background thread with asyncio event loop)
-      └── No ports bound yet — just an event loop waiting
+  └── ProxyServer constructed; httpx monkey-patch installed
+      └── No listener threads, no ports bound — per-session only
 
 tracker.track(data_id="dp_1", combo_id="gpt4o+haiku")
   └── Creates a SessionInfo
   └── Binds a NEW TCP port (e.g. 59198) for this session
+  └── Spawns a listener thread that accepts on that port
   └── Sets ContextVar: _session_port_var = 59198
   └── Returns session env vars for subprocess use
   └── ALL traffic on port 59198 → attributed to this session
 
 track() exit:
   └── Restore ContextVar
-  └── Close session port (cancel pending tasks, unbind)
-  └── End session (archive records)
+  └── Close session listener socket; listener thread exits on next accept()
+  └── In-flight connection threads finish and write to the archived session
+  └── End session (move from active → ended in SessionManager)
 ```
 
 ### In-process path detail
@@ -188,47 +190,47 @@ track(combo_id="gpt4o+gpt4o-mini") → port 59205
 
 ## What lives where
 
-### agentproxy (the proxy server)
+### `agentopt.proxy` (the proxy server)
 
-- asyncio TCP server, one listening socket per active session
-- CONNECT tunnel handling with TLS termination
-- Direct mode: read `X-AgentOpt-Target` header for upstream routing
-- CA certificate generation and caching (`cryptography` library)
-- Hostname filter: only MITM known LLM API hosts, passthrough everything else
-- Forward request to real provider over HTTPS
-- Parse response: extract model, token counts, latency
-- Fire `on_send` / `on_record` hooks
-- Response cache (SQLite-backed, optional)
-- Store call records per session
+Sync, blocking I/O, thread-per-connection.  No asyncio.  Modules:
 
-### agentopt (the optimization layer)
+- **`server.py`** — `ProxyServer`.  Per-session listener threads, one connection thread per accept.  Single `_process_and_respond` lifecycle (cache → forward → record → respond) shared by both arrival modes.  `http.client` for upstream forwarding; `ssl.SSLContext.wrap_socket` for CONNECT-mode TLS termination.
+- **`providers.py`** — `Provider` dataclass and `ProviderRegistry`.  One per `ProxyServer` instance, so registrations don't leak between trackers.  Defines path patterns (direct-mode auto-routing) and the hostname intercept set (CONNECT-mode MITM filter).
+- **`usage.py`** — pure token-extraction functions for OpenAI / Anthropic / Gemini response shapes (JSON object, JSON array, SSE).  Raises `UsageExtractionError` with a structured diagnostic on miss; never reports zero tokens silently.
+- **`certs.py`** — local CA at `~/.agentopt/ca/`.  Generates a self-signed root on first run; mints per-hostname leaf certs on demand (cached in memory).  Builds a merged `bundle.pem` (system CAs + ours) so subprocesses can still reach non-LLM HTTPS hosts.
+- **`cache.py`** — `ResponseCache`.  In-memory dict, optionally persisted to SQLite via a daemon flush thread.  Keyed by a hash of the request body (excluding `stream`).
+- **`session.py`** — `SessionManager`.  Active and archived sessions; `add_record` checks both so a slow upstream that finishes after `end_session` doesn't drop its record.
+- **`interceptor.py`** — the httpx monkey-patch.  Path-pattern set is mutable so `LLMTracker.register_provider` can extend it for runtime-registered providers.
 
-- Selector algorithms (BruteForce, ArmElimination, Bayesian, etc.)
-- Combo generation and scheduling
-- `agent_maker()` factory pattern
-- Evaluation and scoring
-- `tracker.track()` for session management
-- `tracker.get_session_env()` for subprocess environment
+### `agentopt.proxy.LLMTracker` (the public surface)
 
-### The httpx patch (4 lines, no logic)
+- `tracker.start()` / `tracker.stop()` lifecycle
+- `tracker.track(data_id, combo_id, agent_id)` context manager — opens a session port and sets the ContextVar
+- `tracker.get_session_env(session)` — env-var dict for subprocess agents
+- `tracker.register_provider(name, base_url, path_patterns)` — extends the per-server registry, the CONNECT-mode hostname set, and the in-process httpx-patch path set, all at once
+- `tracker.get_records(...)`, `tracker.get_usage(...)` — query recorded calls
 
-- Check if request is an LLM API call
-- Read session port from ContextVar
+### The httpx patch (one function, no business logic)
+
+- `_is_llm_request(request)`: POST + path matches a known LLM endpoint
+- Read session port from `ContextVar`
 - Rewrite URL to `http://localhost:{port}/path`
 - Add `X-AgentOpt-Target` header with original base URL
 
-### The subprocess redirect (2 env vars, no logic)
+### The subprocess redirect (env vars, no logic)
 
 - `HTTPS_PROXY=http://127.0.0.1:{port}`
 - `SSL_CERT_FILE=~/.agentopt/ca/bundle.pem`
+- `REQUESTS_CA_BUNDLE=...`, `NODE_EXTRA_CA_CERTS=...` for non-stdlib clients
 
 ## Known LLM API hostnames
 
-The proxy only intercepts CONNECT requests to these hostnames (passthrough for everything else):
+The proxy only intercepts CONNECT requests to these hostnames (everything else is tunnelled raw, no MITM):
 
 - `api.openai.com`
 - `api.anthropic.com`
 - `generativelanguage.googleapis.com`
+- `cloudcode-pa.googleapis.com` (Gemini CLI OAuth)
 - `bedrock-runtime.*.amazonaws.com`
 - `*.openai.azure.com`
 - `api.mistral.ai`
@@ -236,7 +238,17 @@ The proxy only intercepts CONNECT requests to these hostnames (passthrough for e
 - `api.together.xyz`
 - `api.deepseek.com`
 
-Configurable via `agentproxy.intercept_hosts`.
+Extend at runtime with:
+
+```python
+tracker.register_provider(
+    name="openrouter",
+    base_url="https://openrouter.ai",
+    path_patterns=("/api/v1/chat/completions",),
+)
+```
+
+This updates three places at once: the per-server provider registry (direct-mode routing), the CONNECT-mode hostname set (subprocess MITM filter), and the in-process httpx-patch path set (so `_is_llm_request` returns true for the new path).
 
 ## Why each piece exists
 
@@ -251,15 +263,24 @@ Every layer of complexity is forced by a real constraint, not a design choice:
 
 ## Scoping constraints
 
-1. **Python only** — both agentopt and agentproxy are Python. CA trust configuration targets Python HTTP clients (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`).
-2. **HTTP only** — no gRPC, no WebSocket. HTTP/HTTPS covers 99%+ of current LLM API traffic.
-3. **Build CONNECT tunneling from scratch** — no mitmproxy dependency. A minimal CONNECT handler for known LLM API hostnames is ~200 lines of Python on top of `asyncio`.
-4. **Docker uses sidecar proxy** — `agentproxy` runs inside the container. Self-contained, no host networking dependency.
+1. **Python only** — the proxy is Python.  CA trust config targets Python and Node HTTP clients (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`).
+2. **HTTP only** — no gRPC, no WebSocket.  HTTP/HTTPS covers 99%+ of current LLM API traffic.
+3. **Build CONNECT tunneling from scratch** — no mitmproxy dependency.  A minimal CONNECT handler for known LLM API hostnames is a few hundred lines of stdlib (`socket`, `ssl`, `http.client`).
+4. **Docker uses sidecar proxy** — the proxy runs inside the container.  Self-contained, no host networking dependency.
+
+## Implementation notes
+
+A few non-obvious correctness invariants the implementation has to honour:
+
+- **CONNECT prelude reads must not be buffered.**  If the proxy's CONNECT-line / header parser uses `socket.makefile()`, the `BufferedReader` can pull bytes beyond the header terminator into user space — and on a fast or pipelined client, those over-read bytes include the start of the TLS ClientHello.  Those bytes would never reach `ssl_ctx.wrap_socket` and the handshake fails intermittently.  The implementation reads the prelude with one-byte `recv` calls, only switching to `makefile` after `wrap_socket` is up.
+- **`Content-Length` must be parsed strictly.**  Silently defaulting a missing or malformed header to 0 either truncates the body upstream *or* desynchronizes the keep-alive parser (the unread body bytes get misread as the next request line, corrupting every subsequent request on the connection).  The implementation raises on missing/invalid Content-Length for body-bearing methods.
+- **Token-usage extraction must not silently report zero.**  A successful (HTTP 200) call whose usage we can't parse is a real proxy gap, not a 0-token call.  `usage.py` raises `UsageExtractionError` with a diagnostic naming exactly which keys it searched and which were present; the server attaches that to `CallRecord.error` and uses a `<parse-failed>` sentinel for the model name so the failure surfaces in result summaries.
+- **Late records must not be dropped.**  A blocking upstream request can finish *after* the session's `track()` scope exits.  `SessionManager.add_record` looks up both active and ended sessions so the late record lands in the archive instead of being lost.
 
 ## Open questions
 
-1. **CA certificate compatibility**: do any Python LLM SDKs override `SSL_CERT_FILE` or pin certificates? Need to test against `openai`, `anthropic`, `google-generativeai`, `boto3`.
+1. **CA certificate compatibility**: do any Python LLM SDKs override `SSL_CERT_FILE` or pin certificates?  Need to test against `openai`, `anthropic`, `google-generativeai`, `boto3`.
 
-2. **Agents that bypass HTTPS_PROXY**: some SDK versions may hardcode direct connections. Mitigation: maintain a compatibility matrix per SDK version.
+2. **Agents that bypass `HTTPS_PROXY`**: some SDK versions may hardcode direct connections.  Mitigation: maintain a compatibility matrix per SDK version.
 
-3. **Streaming responses**: most LLM APIs use SSE streaming. The proxy needs to handle `Transfer-Encoding: chunked` and `text/event-stream` responses correctly — forwarding chunks as they arrive rather than buffering the full response. Token counting may need to happen on the accumulated stream.
+3. **Real-time streaming forwarding**: SSE / `Transfer-Encoding: chunked` responses are *parsed* correctly today (the SSE token-extractor handles Anthropic's split `message_start` / `message_delta` usage events and Gemini's `usageMetadata`), but the proxy currently buffers the full upstream response before sending it back to the client — so the client doesn't see chunks land in real time.  For evaluation workflows this is fine (you read the final result anyway).  For interactive use you'd want chunk-by-chunk forwarding while still accumulating SSE frames for token extraction.

--- a/src/agentopt/proxy/interceptor.py
+++ b/src/agentopt/proxy/interceptor.py
@@ -11,7 +11,7 @@ untouched.
 from __future__ import annotations
 
 from contextvars import ContextVar
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Iterable, Optional, Set
 
 import httpx
 
@@ -28,19 +28,32 @@ _session_port_var: ContextVar[Optional[int]] = ContextVar(
 
 
 # ---------------------------------------------------------------------------
-# Path-pattern detection — derived from the provider registry so the
-# patch and the proxy stay in sync as new providers are added.
+# Path-pattern detection
 # ---------------------------------------------------------------------------
+# Mutable so ``LLMTracker.register_provider`` can extend it.  Without that
+# hook, paths from a runtime-registered provider would never match here,
+# the patch would skip the redirect, and the proxy would never see those
+# in-process calls — silent loss of tracking for any custom provider.
+#
+# The set is process-wide rather than per-tracker because the ContextVar
+# port already handles per-session isolation — we only decide WHETHER to
+# redirect here, not WHERE.
+
+_LLM_PATH_PATTERNS: Set[str] = {
+    pattern
+    for provider in DEFAULT_PROVIDERS.values()
+    for pattern in provider.path_patterns
+}
 
 
-def _collect_llm_path_patterns() -> Tuple[str, ...]:
-    patterns: list[str] = []
-    for provider in DEFAULT_PROVIDERS.values():
-        patterns.extend(provider.path_patterns)
-    return tuple(patterns)
+def register_extra_llm_paths(patterns: Iterable[str]) -> None:
+    """Add path patterns the interceptor should treat as LLM endpoints.
 
-
-_LLM_PATH_PATTERNS: Tuple[str, ...] = _collect_llm_path_patterns()
+    Called by :meth:`LLMTracker.register_provider` so in-process httpx
+    calls to runtime-registered providers get redirected through the
+    proxy like the built-ins.
+    """
+    _LLM_PATH_PATTERNS.update(patterns)
 
 
 def _is_llm_request(request: httpx.Request) -> bool:

--- a/src/agentopt/proxy/interceptor.py
+++ b/src/agentopt/proxy/interceptor.py
@@ -1,59 +1,63 @@
-"""httpx monkey-patching — redirect LLM requests through the proxy server.
+"""httpx monkey-patch — redirect in-process LLM calls to the session proxy.
 
-Thin URL rewrite + header injection.  The session port (from a ContextVar)
-determines which session-specific proxy port to target.  All logic lives
-in the proxy server.
+The active session's ephemeral proxy port lives in a ``ContextVar`` set by
+``LLMTracker.track()``.  When httpx is about to send a POST whose URL
+matches a known LLM endpoint, we rewrite it to
+``http://127.0.0.1:{port}/...`` and forward the original base URL through
+the ``X-AgentOpt-Target`` header.  Everything else is passed through
+untouched.
 """
 
+from __future__ import annotations
+
 from contextvars import ContextVar
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 import httpx
 
-from .providers import TARGET_HEADER
+from .providers import DEFAULT_PROVIDERS, TARGET_HEADER
+
 
 # ---------------------------------------------------------------------------
-# ContextVar — the active session's proxy port (set by LLMTracker.track())
+# Active-session port — set by ``LLMTracker.track()``
 # ---------------------------------------------------------------------------
 
 _session_port_var: ContextVar[Optional[int]] = ContextVar(
-    "agentopt_session_port", default=None
+    "agentopt_session_port", default=None,
 )
 
+
 # ---------------------------------------------------------------------------
-# State
+# Path-pattern detection — derived from the provider registry so the
+# patch and the proxy stay in sync as new providers are added.
 # ---------------------------------------------------------------------------
 
-_original_sync_send: Optional[Callable] = None
-_original_async_send: Optional[Callable] = None
-_installed = False
 
-# URL path patterns that indicate LLM API endpoints.
-_LLM_PATH_PATTERNS = (
-    "/chat/completions",
-    "/v1/messages",
-    "/v1/responses",
-    "/v1beta/models",
-    "/v1/models",
-    "/v1internal:generateContent",
-    "/v1internal:streamGenerateContent",
-)
+def _collect_llm_path_patterns() -> Tuple[str, ...]:
+    patterns: list[str] = []
+    for provider in DEFAULT_PROVIDERS.values():
+        patterns.extend(provider.path_patterns)
+    return tuple(patterns)
+
+
+_LLM_PATH_PATTERNS: Tuple[str, ...] = _collect_llm_path_patterns()
 
 
 def _is_llm_request(request: httpx.Request) -> bool:
-    """Check if this request targets a known LLM API endpoint."""
+    """True if *request* targets a known LLM API endpoint via POST."""
     if request.method != "POST":
         return False
     path = request.url.raw_path.decode("ascii", errors="ignore")
     return any(pattern in path for pattern in _LLM_PATH_PATTERNS)
 
 
-def _rewrite_request(request: httpx.Request, session_port: int) -> httpx.Request:
-    """Create a new ``httpx.Request`` pointing at the session proxy port.
+# ---------------------------------------------------------------------------
+# URL rewrite
+# ---------------------------------------------------------------------------
 
-    The original base URL is forwarded as ``X-AgentOpt-Target`` so the
-    proxy knows where to route upstream.
-    """
+
+def _rewrite_request(request: httpx.Request, session_port: int) -> httpx.Request:
+    """Build a localhost-targeted clone of *request* for the proxy."""
     original_url = request.url
     original_base = f"{original_url.scheme}://{original_url.host}"
     if original_url.port and original_url.port not in (80, 443):
@@ -63,13 +67,14 @@ def _rewrite_request(request: httpx.Request, session_port: int) -> httpx.Request
     if original_url.query:
         remaining += "?" + original_url.query.decode("ascii", errors="ignore")
 
-    new_url = f"http://127.0.0.1:{session_port}{remaining}"
-
     headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
     headers[TARGET_HEADER] = original_base
 
     return httpx.Request(
-        method=request.method, url=new_url, headers=headers, content=request.content,
+        method=request.method,
+        url=f"http://127.0.0.1:{session_port}{remaining}",
+        headers=headers,
+        content=request.content,
     )
 
 
@@ -77,15 +82,18 @@ def _rewrite_request(request: httpx.Request, session_port: int) -> httpx.Request
 # Install / uninstall
 # ---------------------------------------------------------------------------
 
+_original_sync_send: Optional[Callable] = None
+_original_async_send: Optional[Callable] = None
+_installed = False
+
 
 def install_redirect() -> None:
-    """Monkey-patch ``httpx`` to redirect LLM requests through the proxy.
+    """Monkey-patch ``httpx.Client.send`` and ``AsyncClient.send``.
 
-    Non-LLM requests and requests outside an active tracking session are
-    passed through unmodified.
+    Idempotent.  Requests outside an active tracking session, or whose
+    URL doesn't look like an LLM call, are passed through unmodified.
     """
     global _original_sync_send, _original_async_send, _installed
-
     if _installed:
         return
 
@@ -93,7 +101,7 @@ def install_redirect() -> None:
     _original_async_send = httpx.AsyncClient.send
 
     def _patched_sync_send(
-        self: Any, request: httpx.Request, *, stream: bool = False, **kwargs: Any
+        self: Any, request: httpx.Request, *, stream: bool = False, **kwargs: Any,
     ) -> httpx.Response:
         if _is_llm_request(request):
             port = _session_port_var.get()
@@ -102,7 +110,7 @@ def install_redirect() -> None:
         return _original_sync_send(self, request, stream=stream, **kwargs)  # type: ignore[misc]
 
     async def _patched_async_send(
-        self: Any, request: httpx.Request, *, stream: bool = False, **kwargs: Any
+        self: Any, request: httpx.Request, *, stream: bool = False, **kwargs: Any,
     ) -> httpx.Response:
         if _is_llm_request(request):
             port = _session_port_var.get()
@@ -116,9 +124,8 @@ def install_redirect() -> None:
 
 
 def uninstall_redirect() -> None:
-    """Restore the original ``httpx.Client.send`` methods."""
+    """Restore the original ``httpx`` send methods."""
     global _original_sync_send, _original_async_send, _installed
-
     if not _installed:
         return
 

--- a/src/agentopt/proxy/providers.py
+++ b/src/agentopt/proxy/providers.py
@@ -1,37 +1,70 @@
-"""Provider registry and auto-detection for LLM API routing."""
+"""LLM provider catalog: hostnames, base URLs, path patterns.
+
+A provider tells the proxy two things:
+
+* its **hostname** — CONNECT mode uses this to decide whether to MITM
+  the TLS tunnel.
+* its **path patterns** — direct mode uses these to auto-route requests
+  by URL path when no ``X-AgentOpt-Target`` header is set.
+
+`ProviderRegistry` owns the catalog per `ProxyServer` instance, so a
+``register_provider`` call on one tracker doesn't leak to another.
+
+The free functions ``detect_provider`` / ``resolve_target`` /
+``should_intercept`` operate against the built-in defaults and exist
+mainly as a stable read-only API for tests and external callers.
+"""
+
+from __future__ import annotations
 
 import fnmatch
 from dataclasses import dataclass
 from typing import Dict, Optional, Set, Tuple
+from urllib.parse import urlparse
+
+
+# Header set by the httpx monkey-patch to carry the original base URL
+# through the localhost rewrite.  Direct-mode resolution checks for it
+# before falling back to path-pattern detection.
+TARGET_HEADER = "x-agentopt-target"
 
 
 @dataclass(frozen=True)
-class ProviderConfig:
-    """Configuration for a known LLM API provider."""
+class Provider:
+    """An LLM API provider known to the proxy."""
 
     name: str
     base_url: str
     path_patterns: Tuple[str, ...]
 
+    @property
+    def hostname(self) -> str:
+        return urlparse(self.base_url).hostname or ""
 
-# Built-in providers — used for subprocess agent auto-detection.
-DEFAULT_PROVIDERS: Dict[str, ProviderConfig] = {
-    "openai": ProviderConfig(
+
+# Backward-compat alias.
+ProviderConfig = Provider
+
+
+# Built-in providers — the proxy MITMs their hostnames and auto-detects
+# their request paths.
+_BUILTIN_PROVIDERS: Tuple[Provider, ...] = (
+    Provider(
         name="openai",
         base_url="https://api.openai.com",
         path_patterns=("/v1/chat/completions", "/chat/completions", "/v1/responses",),
     ),
-    "anthropic": ProviderConfig(
+    Provider(
         name="anthropic",
         base_url="https://api.anthropic.com",
         path_patterns=("/v1/messages",),
     ),
-    "google": ProviderConfig(
+    Provider(
         name="google",
         base_url="https://generativelanguage.googleapis.com",
-        path_patterns=("/v1beta/models", "/v1/models",),
+        path_patterns=("/v1beta/models", "/v1/models"),
     ),
-    "gemini-cli-oauth": ProviderConfig(
+    Provider(
         name="gemini-cli-oauth",
         base_url="https://cloudcode-pa.googleapis.com",
         path_patterns=(
@@ -39,53 +72,112 @@ DEFAULT_PROVIDERS: Dict[str, ProviderConfig] = {
             "/v1internal:streamGenerateContent",
         ),
     ),
-}
+)
 
-# Header name used by the httpx monkey-patch to pass the original base URL.
-TARGET_HEADER = "x-agentopt-target"
-
-# ---------------------------------------------------------------------------
-# Known LLM API hostnames — used for CONNECT-mode interception.
-# Only CONNECT requests to these hosts are TLS-terminated and inspected.
-# Everything else is tunneled through as a transparent passthrough.
-# ---------------------------------------------------------------------------
-
-INTERCEPT_HOSTS: Set[str] = {
-    "api.openai.com",
-    "api.anthropic.com",
-    "generativelanguage.googleapis.com",
-    "cloudcode-pa.googleapis.com",
+# Extra LLM hostnames the proxy MITMs in CONNECT mode but has no in-process
+# path patterns for — they're only ever hit by subprocess agents going
+# through HTTPS_PROXY.
+_EXTRA_INTERCEPT_HOSTS: Tuple[str, ...] = (
     "api.mistral.ai",
     "api.groq.com",
     "api.together.xyz",
     "api.deepseek.com",
-}
+)
 
-# Wildcard patterns (matched with fnmatch).
-INTERCEPT_PATTERNS: Tuple[str, ...] = (
+# Wildcard hostname patterns (fnmatch).  Used for providers whose
+# concrete hostname varies per deployment.
+_INTERCEPT_PATTERNS: Tuple[str, ...] = (
     "bedrock-runtime.*.amazonaws.com",
     "*.openai.azure.com",
 )
 
 
-def should_intercept(hostname: str) -> bool:
-    """Return ``True`` if CONNECT traffic to *hostname* should be intercepted."""
-    if hostname in INTERCEPT_HOSTS:
-        return True
-    return any(fnmatch.fnmatch(hostname, pat) for pat in INTERCEPT_PATTERNS)
+class ProviderRegistry:
+    """Per-instance LLM provider catalog used by ``ProxyServer``.
+
+    Holds one mutable copy of the built-in providers plus the CONNECT-mode
+    intercept set.  Each ``ProxyServer`` instance gets its own.
+    """
+
+    def __init__(self) -> None:
+        self.providers: Dict[str, Provider] = {p.name: p for p in _BUILTIN_PROVIDERS}
+        self._intercept_hosts: Set[str] = set(_EXTRA_INTERCEPT_HOSTS) | {
+            p.hostname for p in self.providers.values() if p.hostname
+        }
+        self._intercept_patterns = list(_INTERCEPT_PATTERNS)
+
+    def register(
+        self, name: str, base_url: str, path_patterns: Tuple[str, ...],
+    ) -> None:
+        """Add or replace a provider.
+
+        Updates the path-pattern registry (direct mode) and the hostname
+        intercept set (CONNECT mode).
+        """
+        provider = Provider(name=name, base_url=base_url, path_patterns=path_patterns)
+        self.providers[name] = provider
+        if provider.hostname:
+            self._intercept_hosts.add(provider.hostname)
+
+    def detect(self, path: str) -> Optional[Provider]:
+        """First provider whose path pattern is a substring of *path*."""
+        for provider in self.providers.values():
+            for pattern in provider.path_patterns:
+                if pattern in path:
+                    return provider
+        return None
+
+    def resolve_target(self, path: str, headers: Dict[str, str],) -> Tuple[str, str]:
+        """Determine ``(upstream_base_url, upstream_path)`` for a request.
+
+        Resolution order:
+        1. ``X-AgentOpt-Target`` header (set by the httpx monkey-patch).
+        2. Path-pattern auto-detection.
+
+        Raises ``ValueError`` if neither resolves.
+        """
+        target = headers.get(TARGET_HEADER)
+        if target:
+            return target.rstrip("/"), path
+
+        provider = self.detect(path)
+        if provider is not None:
+            return provider.base_url, path
+
+        raise ValueError(
+            f"Cannot resolve LLM provider for path {path!r}. "
+            "Either set the X-AgentOpt-Target header (in-process) or "
+            "register the provider via register_provider()."
+        )
+
+    def should_intercept(self, hostname: str) -> bool:
+        """True if CONNECT traffic to *hostname* should be TLS-terminated."""
+        if hostname in self._intercept_hosts:
+            return True
+        return any(fnmatch.fnmatch(hostname, pat) for pat in self._intercept_patterns)
+
+
+# ---------------------------------------------------------------------------
+# Module-level read-only API — used by tests and as a stable public surface.
+# These reflect only the built-ins; calls to ``register_provider`` on a
+# tracker do NOT mutate them.
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROVIDERS: Dict[str, Provider] = {p.name: p for p in _BUILTIN_PROVIDERS}
+
+INTERCEPT_HOSTS: Set[str] = set(_EXTRA_INTERCEPT_HOSTS) | {
+    p.hostname for p in _BUILTIN_PROVIDERS if p.hostname
+}
+
+INTERCEPT_PATTERNS: Tuple[str, ...] = _INTERCEPT_PATTERNS
 
 
 def detect_provider(
-    path: str, providers: Optional[Dict[str, ProviderConfig]] = None,
-) -> Optional[ProviderConfig]:
-    """Match a request path against registered provider patterns.
-
-    Returns the first matching ``ProviderConfig``, or ``None``.
-    """
-    if providers is None:
-        providers = DEFAULT_PROVIDERS
-
-    for provider in providers.values():
+    path: str, providers: Optional[Dict[str, Provider]] = None,
+) -> Optional[Provider]:
+    """Match a path against the built-in providers (or a custom dict)."""
+    catalog = providers if providers is not None else DEFAULT_PROVIDERS
+    for provider in catalog.values():
         for pattern in provider.path_patterns:
             if pattern in path:
                 return provider
@@ -93,47 +185,24 @@ def detect_provider(
 
 
 def resolve_target(
-    path: str,
-    headers: Dict[str, str],
-    providers: Optional[Dict[str, ProviderConfig]] = None,
+    path: str, headers: Dict[str, str], providers: Optional[Dict[str, Provider]] = None,
 ) -> Tuple[str, str]:
-    """Determine the upstream base URL and path for a proxied request.
-
-    Resolution order:
-    1. ``X-AgentOpt-Target`` header — set by the httpx monkey-patch for
-       in-process agents.  Contains the exact original base URL, which
-       may be a custom / self-hosted endpoint (e.g. Azure OpenAI).
-    2. Path-pattern auto-detection against the **provider registry** —
-       fallback for subprocess agents where custom headers are not
-       available.
-
-    Returns
-    -------
-    (target_base_url, upstream_path)
-        *target_base_url* is e.g. ``"https://api.openai.com"``.
-        *upstream_path* is e.g. ``"/v1/chat/completions"``.
-
-    Raises
-    ------
-    ValueError
-        If the provider cannot be resolved by either mechanism.
-    """
-    if providers is None:
-        providers = DEFAULT_PROVIDERS
-
-    # 1. Explicit header (in-process agents — exact target, supports
-    #    Azure / self-hosted / custom OpenAI-compatible endpoints)
+    """Free-function form of ``ProviderRegistry.resolve_target``."""
     target = headers.get(TARGET_HEADER)
     if target:
         return target.rstrip("/"), path
-
-    # 2. Auto-detect from path pattern (subprocess agents)
     provider = detect_provider(path, providers)
     if provider is not None:
         return provider.base_url, path
-
     raise ValueError(
         f"Cannot resolve LLM provider for path {path!r}. "
         "Either set the X-AgentOpt-Target header (in-process) or "
         "register the provider via register_provider()."
     )
+
+
+def should_intercept(hostname: str) -> bool:
+    """Built-in form of ``ProviderRegistry.should_intercept``."""
+    if hostname in INTERCEPT_HOSTS:
+        return True
+    return any(fnmatch.fnmatch(hostname, pat) for pat in INTERCEPT_PATTERNS)

--- a/src/agentopt/proxy/server.py
+++ b/src/agentopt/proxy/server.py
@@ -233,14 +233,18 @@ class ProxyServer:
     def _handle_connection(
         self, client_sock: socket.socket, session: SessionInfo,
     ) -> None:
-        """Per-connection top-level: peek first line, dispatch to mode."""
-        rfile = wfile = None
+        """Per-connection top-level: peek first line, dispatch to mode.
+
+        The first line is read with unbuffered ``recv`` rather than via
+        ``makefile``.  A BufferedReader can pull whatever's currently in
+        the kernel buffer into user space (typically up to 8 KB), and on
+        the CONNECT path those over-read bytes can include the start of
+        the client's TLS ClientHello — which would then be invisible to
+        ``ssl_ctx.wrap_socket`` and cause intermittent handshake failures.
+        """
         try:
             client_sock.settimeout(120)
-            rfile = client_sock.makefile("rb")
-            wfile = client_sock.makefile("wb")
-
-            first_line = rfile.readline()
+            first_line = _recv_line_raw(client_sock)
             if not first_line:
                 return
             line = first_line.decode("utf-8", errors="replace").strip()
@@ -249,20 +253,25 @@ class ProxyServer:
                 return
 
             if parts[0].upper() == "CONNECT":
-                self._handle_connect(client_sock, rfile, wfile, line, session)
+                # Stay on raw I/O through the prelude + TLS upgrade.
+                self._handle_connect(client_sock, line, session)
             else:
-                self._direct_request_loop(rfile, wfile, first_line, session)
+                # Plaintext direct mode — no upgrade, buffered I/O is safe.
+                rfile = client_sock.makefile("rb")
+                wfile = client_sock.makefile("wb")
+                try:
+                    self._direct_request_loop(rfile, wfile, first_line, session)
+                finally:
+                    for f in (rfile, wfile):
+                        try:
+                            f.close()
+                        except Exception:
+                            pass
         except (ConnectionError, OSError, ssl.SSLError, socket.timeout):
             pass
         except Exception:
             logger.exception("connection handler crashed")
         finally:
-            for f in (rfile, wfile):
-                if f is not None:
-                    try:
-                        f.close()
-                    except Exception:
-                        pass
             _close_quietly(client_sock)
 
     # ==================================================================
@@ -270,14 +279,16 @@ class ProxyServer:
     # ==================================================================
 
     def _handle_connect(
-        self,
-        client_sock: socket.socket,
-        rfile: BinaryIO,
-        wfile: BinaryIO,
-        request_line: str,
-        session: SessionInfo,
+        self, client_sock: socket.socket, request_line: str, session: SessionInfo,
     ) -> None:
-        """Handle an HTTP CONNECT tunnel — passthrough or MITM."""
+        """Handle an HTTP CONNECT tunnel — passthrough or MITM.
+
+        The prelude (CONNECT line + headers + ``200 Connection Established``)
+        is transacted with unbuffered socket I/O so no client bytes leak
+        into a user-space buffer before ``wrap_socket`` takes over.  Once
+        TLS is up the SSL layer frames the byte stream cleanly, so it's
+        safe to switch back to ``makefile`` for the inner request loop.
+        """
         target = request_line.split()[1]
         if ":" in target:
             host_part, port_part = target.rsplit(":", 1)
@@ -286,22 +297,23 @@ class ProxyServer:
             except ValueError:
                 remote_port = -1
             if not host_part or not (0 < remote_port < 65536):
-                _write_response(
-                    wfile,
-                    400,
-                    {"content-type": "application/json"},
-                    json.dumps(
-                        {"error": f"malformed CONNECT target: {target!r}"}
-                    ).encode(),
+                client_sock.sendall(
+                    _build_response(
+                        400,
+                        {"content-type": "application/json"},
+                        json.dumps(
+                            {"error": f"malformed CONNECT target: {target!r}"}
+                        ).encode(),
+                    )
                 )
                 return
             hostname = host_part
         else:
             hostname, remote_port = target, 443
 
-        # Drain CONNECT headers.
+        # Drain CONNECT headers — raw, no buffered read-ahead.
         while True:
-            h = rfile.readline()
+            h = _recv_line_raw(client_sock)
             if h in (b"\r\n", b"\n", b""):
                 break
 
@@ -309,9 +321,10 @@ class ProxyServer:
             self._connect_passthrough(client_sock, hostname, remote_port)
             return
 
-        # Establish tunnel, then upgrade to TLS.
-        wfile.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-        wfile.flush()
+        # Confirm the tunnel and immediately upgrade.  Crucially, no
+        # bytes have been pulled into a user-space buffer up to this
+        # point, so wrap_socket sees the full TLS handshake stream.
+        client_sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
 
         ssl_ctx = self._ca.get_server_context(hostname)
         try:
@@ -320,6 +333,8 @@ class ProxyServer:
             logger.warning("TLS handshake failed for %s: %s", hostname, exc)
             return
 
+        # SSL handles framing — buffered reads on the TLS socket can't
+        # leak ciphertext out of band, so makefile is fine here.
         tls_rfile = tls_sock.makefile("rb")
         tls_wfile = tls_sock.makefile("wb")
         try:
@@ -764,6 +779,30 @@ def _safe_response_headers(headers: Dict[str, str]) -> Dict[str, str]:
         for k, v in headers.items()
         if k.lower() not in ("transfer-encoding", "content-encoding")
     }
+
+
+def _recv_line_raw(sock: socket.socket, max_len: int = 8192) -> bytes:
+    """Read up to (and including) the next ``\\n`` using unbuffered ``recv``.
+
+    Used for the CONNECT prelude: if we read those lines via a
+    ``BufferedReader`` (``socket.makefile``), the buffer can pull whatever's
+    currently in the kernel's receive queue — typically up to 8 KB —
+    which on the CONNECT path may include the start of the client's TLS
+    ClientHello.  Those over-read bytes would then be invisible to
+    ``ssl_ctx.wrap_socket`` and break the handshake intermittently.
+
+    Per-byte ``recv`` is fine here: the prelude is at most a handful of
+    short lines (well under 1 KB total) and runs once per tunnel.
+    """
+    buf = bytearray()
+    while len(buf) < max_len:
+        chunk = sock.recv(1)
+        if not chunk:
+            return bytes(buf)
+        buf += chunk
+        if chunk == b"\n":
+            return bytes(buf)
+    raise ValueError(f"line exceeded {max_len} bytes without LF")
 
 
 def _bidirectional_relay(a: socket.socket, b: socket.socket) -> None:

--- a/src/agentopt/proxy/server.py
+++ b/src/agentopt/proxy/server.py
@@ -281,7 +281,21 @@ class ProxyServer:
         target = request_line.split()[1]
         if ":" in target:
             host_part, port_part = target.rsplit(":", 1)
-            hostname, remote_port = host_part, int(port_part)
+            try:
+                remote_port = int(port_part)
+            except ValueError:
+                remote_port = -1
+            if not host_part or not (0 < remote_port < 65536):
+                _write_response(
+                    wfile,
+                    400,
+                    {"content-type": "application/json"},
+                    json.dumps(
+                        {"error": f"malformed CONNECT target: {target!r}"}
+                    ).encode(),
+                )
+                return
+            hostname = host_part
         else:
             hostname, remote_port = target, 443
 

--- a/src/agentopt/proxy/server.py
+++ b/src/agentopt/proxy/server.py
@@ -1,49 +1,67 @@
-"""Dual-mode HTTP proxy server for transparent LLM call interception.
+"""Dual-mode HTTP proxy for transparent LLM call interception.
 
-Runs as a background daemon thread.  Each tracking session gets its own
-TCP port — the port IS the session identity.  This eliminates session-ID
-parsing from URLs and makes both in-process and subprocess agents work
-through the same mechanism.
+Each tracking session gets its own ephemeral TCP port — the port IS the
+session identity, so no session IDs in URLs or ContextVars are needed.
 
-Two modes per session port:
+Two arrival modes per port:
 
-* **Direct mode** — in-process agents.  The httpx patch rewrites URLs to
-  ``http://127.0.0.1:{session_port}/...`` with an ``X-AgentOpt-Target``
-  header.  Traffic arrives as plaintext HTTP.
-
-* **CONNECT mode** — subprocess/Docker agents.  The agent's HTTP client
-  honours ``HTTPS_PROXY=http://127.0.0.1:{session_port}`` and sends
-  ``CONNECT hostname:443``.  The proxy terminates TLS using a per-hostname
+* **Direct** — in-process agents whose ``httpx`` calls have been rewritten
+  by :mod:`agentopt.proxy.interceptor` to ``http://127.0.0.1:{port}/...``
+  with an ``X-AgentOpt-Target`` header.  Plaintext.
+* **CONNECT** — subprocess agents driving traffic through
+  ``HTTPS_PROXY=http://127.0.0.1:{port}``.  The proxy answers
+  ``CONNECT host:443`` by TLS-terminating the tunnel using a per-hostname
   certificate from the local CA.
+
+Once a request is parsed, both modes share a single lifecycle:
+``cache → forward → record → respond``.
+
+Implementation: blocking I/O, one thread per accepted connection.  Keeps
+the code linear and lets us use stdlib ``http.client`` for forwarding —
+no asyncio / aiohttp.
 """
 
-import asyncio
-import fnmatch
+from __future__ import annotations
+
+import http.client
 import json
 import logging
+import socket
 import ssl
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from http import HTTPStatus
+from typing import Any, BinaryIO, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 from .cache import CacheEntry, ResponseCache, _make_cache_key
 from .certs import CertificateAuthority
 from .models import CallRecord
 from .providers import (
-    DEFAULT_PROVIDERS,
-    INTERCEPT_HOSTS,
-    INTERCEPT_PATTERNS,
+    DEFAULT_PROVIDERS,  # re-exported for back-compat
+    INTERCEPT_HOSTS,  # re-exported for back-compat
+    INTERCEPT_PATTERNS,  # re-exported for back-compat
+    Provider,
+    ProviderConfig,  # re-exported for back-compat
+    ProviderRegistry,
     TARGET_HEADER,
-    ProviderConfig,
-    resolve_target,
+    resolve_target,  # re-exported for back-compat
 )
 from .session import SessionInfo, SessionManager
+from .usage import (
+    PARSE_FAILED_MODEL,
+    extract_usage,
+    extract_usage_streaming,
+    is_streaming_request,
+)
 
 logger = logging.getLogger(__name__)
 
-# Headers that must not be forwarded to the upstream provider.
+
+# Headers we strip before forwarding to upstream — connection-management
+# meta plus our own routing header.
 _HOP_BY_HOP = frozenset(
     {
         "host",
@@ -57,1053 +75,676 @@ _HOP_BY_HOP = frozenset(
 )
 
 
-# OpenAI-compatible chat/completions paths. Used to detect the streaming
-# `stream_options.include_usage` quirk (Anthropic uses `/v1/messages` and
-# always emits usage, so it's excluded).
-_OPENAI_COMPAT_PATHS = ("/v1/chat/completions", "/v1/completions", "/chat/completions")
+# ---------------------------------------------------------------------------
+# Parsed-request value type
+# ---------------------------------------------------------------------------
 
 
-# Sentinel used as the model name on a record when we successfully
-# intercepted a 200 response but could not extract token usage from its
-# body. Surfaces in result summaries as `tokens: {<parse-failed>: ...}`
-# alongside a logged warning and a populated CallRecord.error.
-PARSE_FAILED_MODEL = "<parse-failed>"
+@dataclass
+class _Request:
+    """One parsed HTTP/1.1 request."""
+
+    method: str
+    path: str
+    headers: Dict[str, str]
+    body: bytes
+    json_body: Dict[str, Any]
 
 
-def _is_openai_compatible_url(url: str) -> bool:
-    """True when *url* targets an OpenAI-style chat/completions endpoint."""
-    path = urlparse(url).path or ""
-    return any(path.endswith(p) for p in _OPENAI_COMPAT_PATHS)
-
-
-def _has_include_usage(request_body: dict) -> bool:
-    """True when the request opts in to streaming usage frames."""
-    opts = request_body.get("stream_options")
-    return isinstance(opts, dict) and opts.get("include_usage") is True
-
-
-def _is_streaming_request(request_body: dict, path_or_url: str) -> bool:
-    """True when the request is asking for a streaming response.
-
-    Detects:
-    * OpenAI / Anthropic style — ``"stream": true`` in the request body.
-    * Google Gemini — ``:streamGenerateContent`` endpoint, optionally with
-      ``?alt=sse`` query param.  Gemini does not put a ``stream`` flag in
-      the request body, so URL-based detection is the only signal.
-    """
-    if request_body.get("stream") is True:
-        return True
-    if "streamGenerateContent" in path_or_url or "alt=sse" in path_or_url:
-        return True
-    return False
-
-
-def _gemini_completion_tokens(usage: dict) -> int:
-    """Compute output token count for Gemini's ``usageMetadata``.
-
-    Gemini's thinking models report visible output under
-    ``candidatesTokenCount`` and reasoning tokens separately under
-    ``thoughtsTokenCount``. Both bill as output, so the proxy reports
-    the sum. Falls back to ``totalTokenCount - promptTokenCount`` when
-    individual fields aren't broken out.
-    """
-    candidates = usage.get("candidatesTokenCount") or 0
-    thoughts = usage.get("thoughtsTokenCount") or 0
-    if candidates or thoughts:
-        return candidates + thoughts
-    total = usage.get("totalTokenCount")
-    prompt = usage.get("promptTokenCount") or 0
-    if isinstance(total, int) and total > prompt:
-        return total - prompt
-    return 0
-
-
-def _parse_usage(body: dict) -> Optional[dict]:
-    """Extract model and token usage from an LLM API response body.
-
-    Supports OpenAI/Anthropic (``model`` + ``usage``) and Google Gemini
-    (``modelVersion`` + ``usageMetadata``).  For Gemini thinking models,
-    ``thoughtsTokenCount`` is folded into the completion token count.
-    """
-    model = body.get("model") or body.get("modelVersion")
-    usage = body.get("usage") or body.get("usageMetadata")
-    if not model or not usage:
-        return None
-    prompt_tokens = (
-        usage.get("prompt_tokens")
-        or usage.get("input_tokens")
-        or usage.get("promptTokenCount")
-        or 0
-    )
-    completion_tokens = (
-        usage.get("completion_tokens")
-        or usage.get("output_tokens")
-        or _gemini_completion_tokens(usage)
-    )
-    return {
-        "model": model,
-        "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
-    }
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
 
 
 class ProxyServer:
-    """Dual-mode (Direct + CONNECT) HTTP proxy for LLM API calls.
+    """Synchronous, thread-per-connection proxy.
 
-    Each tracking session gets a dedicated TCP port via
-    :meth:`open_session_port`.  All traffic on that port is attributed
-    to the session — no session IDs in URLs or ContextVars needed.
+    One listener thread per session port; each accepted connection runs
+    in its own thread and handles either CONNECT (TLS termination + LLM
+    request loop) or direct (plaintext + LLM request loop).
     """
 
     def __init__(
         self,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         cache: Optional[ResponseCache] = None,
         ca: Optional[CertificateAuthority] = None,
-        providers: Optional[Dict[str, ProviderConfig]] = None,
+        providers: Optional[Dict[str, Provider]] = None,
     ) -> None:
         self.session_manager = SessionManager()
         self._host = host
         self._cache = cache
         self._ca = ca
-        self._providers: Dict[str, ProviderConfig] = dict(
-            providers or DEFAULT_PROVIDERS
-        )
-        # Per-instance CONNECT intercept set — seeded from module defaults.
-        # register_provider() extends this with hostnames from custom providers.
-        self._intercept_hosts: Set[str] = set(INTERCEPT_HOSTS)
-        self._intercept_patterns: List[str] = list(INTERCEPT_PATTERNS)
+
+        self._registry = ProviderRegistry()
+        if providers:
+            for p in providers.values():
+                self._registry.register(p.name, p.base_url, p.path_patterns)
+        # Back-compat: tests inspect ``_providers`` for membership.
+        self._providers = self._registry.providers
+
+        # session_id -> (listen_sock, listener_thread, port)
+        self._listeners: Dict[str, Tuple[socket.socket, threading.Thread, int]] = {}
+        self._listeners_lock = threading.Lock()
 
         # Hostnames we've already warned about for the OpenAI streaming
-        # `stream_options.include_usage` quirk. Deduped to avoid log spam.
-        self._openai_stream_usage_warned: Set[str] = set()
-
-        # Lifecycle
-        self._thread: Optional[threading.Thread] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._shutdown_event: Optional[asyncio.Event] = None
-        self._started = threading.Event()
-
-        # Per-session listeners: session_id -> (asyncio.Server, port)
-        self._session_listeners: Dict[str, Tuple[asyncio.Server, int]] = {}
-        # Per-session connection tasks for clean cancellation.
-        self._session_tasks: Dict[str, List[asyncio.Task]] = {}
-
-    # ------------------------------------------------------------------
-    # Public helpers
-    # ------------------------------------------------------------------
-
-    def register_provider(
-        self, name: str, base_url: str, path_patterns: tuple,
-    ) -> None:
-        """Add or replace a provider in the registry.
-
-        Registers the provider for both modes:
-        * **Direct mode** — adds to path-pattern auto-detection registry.
-        * **CONNECT mode** — adds the hostname from *base_url* to the
-          CONNECT intercept set, so subprocess agents routing through
-          ``HTTPS_PROXY`` get TLS-terminated and tracked.
-        """
-        self._providers[name] = ProviderConfig(
-            name=name, base_url=base_url, path_patterns=path_patterns,
-        )
-        hostname = urlparse(base_url).hostname
-        if hostname:
-            self._intercept_hosts.add(hostname)
-
-    def _should_intercept(self, hostname: str) -> bool:
-        """Return ``True`` if CONNECT traffic to *hostname* should be intercepted."""
-        if hostname in self._intercept_hosts:
-            return True
-        return any(fnmatch.fnmatch(hostname, pat) for pat in self._intercept_patterns)
-
-    # ------------------------------------------------------------------
-    # Session ports
-    # ------------------------------------------------------------------
-
-    def open_session_port(self, session_id: str) -> int:
-        """Bind a new port for *session_id*.  Returns the port number.
-
-        Thread-safe — can be called from the main thread while the proxy
-        event loop runs in its background thread.
-        """
-        assert self._loop is not None, "call start() first"
-        future = asyncio.run_coroutine_threadsafe(
-            self._open_session_port_async(session_id), self._loop,
-        )
-        return future.result(timeout=5)
-
-    def close_session_port(self, session_id: str) -> None:
-        """Close the port for *session_id*.  Thread-safe."""
-        assert self._loop is not None
-        future = asyncio.run_coroutine_threadsafe(
-            self._close_session_port_async(session_id), self._loop,
-        )
-        future.result(timeout=5)
-
-    async def _open_session_port_async(self, session_id: str) -> int:
-        session = self.session_manager.get_session(session_id)
-        assert session is not None, f"session {session_id} not found"
-        self._session_tasks[session_id] = []
-
-        def _on_connect(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
-            task = asyncio.ensure_future(self._handle_session_connection(session, r, w))
-            self._session_tasks.get(session_id, []).append(task)
-            task.add_done_callback(
-                lambda t: self._session_tasks.get(session_id, []).remove(t)
-                if t in self._session_tasks.get(session_id, [])
-                else None
-            )
-
-        # reuse_address=True lets us bind a fresh ephemeral port immediately
-        # even when a recently closed one is still in TIME_WAIT — prevents
-        # port exhaustion during long sweeps with many sessions.
-        server = await asyncio.start_server(
-            _on_connect, self._host, 0, reuse_address=True,
-        )
-        port = server.sockets[0].getsockname()[1]
-        self._session_listeners[session_id] = (server, port)
-        logger.debug("Session %s listening on port %d", session_id, port)
-        return port
-
-    async def _close_session_port_async(self, session_id: str) -> None:
-        entry = self._session_listeners.pop(session_id, None)
-        if entry is not None:
-            server, port = entry
-            server.close()
-            await server.wait_closed()
-            # Cancel any pending connection tasks (e.g. keep-alive waits).
-            for task in self._session_tasks.pop(session_id, []):
-                task.cancel()
-            logger.debug("Session %s port %d closed", session_id, port)
+        # `stream_options.include_usage` quirk.  Deduped to avoid log spam.
+        self._stream_warned_hosts: set = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Start the proxy in a background daemon thread."""
-        if self._thread is not None:
-            return
-        self._started.clear()
-        self._thread = threading.Thread(
-            target=self._run_loop, daemon=True, name="agentopt-proxy",
-        )
-        self._thread.start()
-        if not self._started.wait(timeout=10):
-            raise RuntimeError("Proxy server failed to start within 10 s")
+        """No-op.  Listeners are bound per-session in ``open_session_port``."""
 
     def stop(self) -> None:
-        """Shut down the proxy server and collect remaining sessions."""
-        if self._loop is None or self._shutdown_event is None:
-            return
+        """Close every listener socket and archive remaining sessions."""
         self.session_manager.force_end_all()
-        self._loop.call_soon_threadsafe(self._shutdown_event.set)
-        if self._thread is not None:
-            self._thread.join(timeout=5)
-            self._thread = None
-
-    def _run_loop(self) -> None:
-        self._loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._serve())
-
-    async def _serve(self) -> None:
-        self._shutdown_event = asyncio.Event()
-        self._started.set()
-        logger.info("Proxy server started")
-        await self._shutdown_event.wait()
-
-        # Close all session listeners.
-        for session_id in list(self._session_listeners):
-            await self._close_session_port_async(session_id)
+        with self._listeners_lock:
+            entries = list(self._listeners.values())
+            self._listeners.clear()
+        for sock, _, _ in entries:
+            _close_quietly(sock)
+        for _, thread, _ in entries:
+            thread.join(timeout=2)
 
     # ------------------------------------------------------------------
-    # Session connection handler
+    # Provider registry
     # ------------------------------------------------------------------
 
-    async def _handle_session_connection(
-        self,
-        session: SessionInfo,
-        reader: asyncio.StreamReader,
-        writer: asyncio.StreamWriter,
+    def register_provider(
+        self, name: str, base_url: str, path_patterns: tuple,
     ) -> None:
-        """Handle a connection on a session port.
+        """Add or replace a provider in this server's registry."""
+        self._registry.register(name, base_url, path_patterns)
 
-        Dispatches to Direct or CONNECT mode.  Loops for HTTP keep-alive.
-        """
+    def _should_intercept(self, hostname: str) -> bool:
+        """Whether CONNECT traffic to *hostname* should be TLS-terminated."""
+        return self._registry.should_intercept(hostname)
+
+    # ------------------------------------------------------------------
+    # Session ports
+    # ------------------------------------------------------------------
+
+    def open_session_port(self, session_id: str) -> int:
+        """Bind a fresh ephemeral port for *session_id* and start accepting."""
+        session = self.session_manager.get_session(session_id)
+        assert session is not None, f"session {session_id} not found"
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((self._host, 0))
+        sock.listen(64)
+        port = sock.getsockname()[1]
+
+        thread = threading.Thread(
+            target=self._listen_loop,
+            args=(sock, session),
+            daemon=True,
+            name=f"agentopt-listener-{session_id}",
+        )
+        with self._listeners_lock:
+            self._listeners[session_id] = (sock, thread, port)
+        thread.start()
+        logger.debug("Session %s listening on port %d", session_id, port)
+        return port
+
+    def close_session_port(self, session_id: str) -> None:
+        """Close *session_id*'s listener.  Connection threads exit on their own."""
+        with self._listeners_lock:
+            entry = self._listeners.pop(session_id, None)
+        if entry is None:
+            return
+        sock, thread, port = entry
+        _close_quietly(sock)
+        thread.join(timeout=2)
+        logger.debug("Session %s port %d closed", session_id, port)
+
+    def get_session_port(self, session_id: str) -> int:
+        """Look up the port bound to *session_id*."""
+        with self._listeners_lock:
+            entry = self._listeners.get(session_id)
+        assert entry is not None, f"no port for session {session_id}"
+        return entry[2]
+
+    # ------------------------------------------------------------------
+    # Listener + connection dispatch
+    # ------------------------------------------------------------------
+
+    def _listen_loop(self, listen_sock: socket.socket, session: SessionInfo,) -> None:
+        """Accept loop for one session port."""
         try:
             while True:
-                first_line = await reader.readline()
-                if not first_line:
-                    break
-                line = first_line.decode("utf-8", errors="replace").strip()
-                if not line:
-                    continue
-                parts = line.split()
-                if len(parts) < 2:
-                    break
-                method = parts[0].upper()
-                if method == "CONNECT":
-                    await self._handle_connect(session, line, reader, writer)
-                    break
-                else:
-                    await self._handle_direct(session, first_line, reader, writer)
-        except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
+                try:
+                    client_sock, _ = listen_sock.accept()
+                except OSError:
+                    return  # listener closed
+                threading.Thread(
+                    target=self._handle_connection,
+                    args=(client_sock, session),
+                    daemon=True,
+                    name=f"agentopt-conn-{session.session_id}",
+                ).start()
+        except Exception:
+            logger.exception("listener loop crashed")
+
+    def _handle_connection(
+        self, client_sock: socket.socket, session: SessionInfo,
+    ) -> None:
+        """Per-connection top-level: peek first line, dispatch to mode."""
+        rfile = wfile = None
+        try:
+            client_sock.settimeout(120)
+            rfile = client_sock.makefile("rb")
+            wfile = client_sock.makefile("wb")
+
+            first_line = rfile.readline()
+            if not first_line:
+                return
+            line = first_line.decode("utf-8", errors="replace").strip()
+            parts = line.split()
+            if len(parts) < 2:
+                return
+
+            if parts[0].upper() == "CONNECT":
+                self._handle_connect(client_sock, rfile, wfile, line, session)
+            else:
+                self._direct_request_loop(rfile, wfile, first_line, session)
+        except (ConnectionError, OSError, ssl.SSLError, socket.timeout):
             pass
         except Exception:
-            logger.exception("Error handling connection")
+            logger.exception("connection handler crashed")
         finally:
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
+            for f in (rfile, wfile):
+                if f is not None:
+                    try:
+                        f.close()
+                    except Exception:
+                        pass
+            _close_quietly(client_sock)
 
     # ==================================================================
-    # CONNECT MODE
+    # CONNECT mode
     # ==================================================================
 
-    async def _handle_connect(
+    def _handle_connect(
         self,
-        session: SessionInfo,
+        client_sock: socket.socket,
+        rfile: BinaryIO,
+        wfile: BinaryIO,
         request_line: str,
-        reader: asyncio.StreamReader,
-        writer: asyncio.StreamWriter,
+        session: SessionInfo,
     ) -> None:
-        """Handle an HTTP CONNECT tunnel request."""
-        parts = request_line.split()
-        if len(parts) < 2:
-            writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-            await writer.drain()
-            return
-
-        target = parts[1]
+        """Handle an HTTP CONNECT tunnel — passthrough or MITM."""
+        target = request_line.split()[1]
         if ":" in target:
-            hostname, port_str = target.rsplit(":", 1)
-            remote_port = int(port_str)
+            host_part, port_part = target.rsplit(":", 1)
+            hostname, remote_port = host_part, int(port_part)
         else:
-            hostname = target
-            remote_port = 443
+            hostname, remote_port = target, 443
 
-        # Drain remaining headers.
+        # Drain CONNECT headers.
         while True:
-            header_line = await reader.readline()
-            if header_line in (b"\r\n", b"\n", b""):
+            h = rfile.readline()
+            if h in (b"\r\n", b"\n", b""):
                 break
 
         if not self._should_intercept(hostname) or self._ca is None:
-            await self._connect_passthrough(hostname, remote_port, reader, writer)
+            self._connect_passthrough(client_sock, hostname, remote_port)
             return
 
-        # Respond 200 to establish the tunnel.
-        writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-        await writer.drain()
+        # Establish tunnel, then upgrade to TLS.
+        wfile.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        wfile.flush()
 
-        # TLS termination in a blocking thread.
         ssl_ctx = self._ca.get_server_context(hostname)
-        raw_sock = writer.transport.get_extra_info("socket").dup()
-        writer.transport.close()
-
-        await asyncio.get_event_loop().run_in_executor(
-            None,
-            self._handle_connect_blocking,
-            raw_sock,
-            ssl_ctx,
-            hostname,
-            remote_port,
-            session,
-        )
-
-    async def _connect_passthrough(
-        self,
-        hostname: str,
-        port: int,
-        client_reader: asyncio.StreamReader,
-        client_writer: asyncio.StreamWriter,
-    ) -> None:
-        """Tunnel traffic through without TLS termination."""
         try:
-            upstream_reader, upstream_writer = await asyncio.open_connection(
-                hostname, port,
-            )
-        except Exception as exc:
-            client_writer.write(f"HTTP/1.1 502 Bad Gateway\r\n\r\n{exc}".encode())
-            await client_writer.drain()
+            tls_sock = ssl_ctx.wrap_socket(client_sock, server_side=True)
+        except (ssl.SSLError, OSError) as exc:
+            logger.warning("TLS handshake failed for %s: %s", hostname, exc)
             return
 
-        client_writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-        await client_writer.drain()
-
-        async def _relay(src: asyncio.StreamReader, dst: asyncio.StreamWriter) -> None:
-            try:
-                while True:
-                    data = await src.read(65536)
-                    if not data:
-                        break
-                    dst.write(data)
-                    await dst.drain()
-            except Exception:
-                pass
-            finally:
+        tls_rfile = tls_sock.makefile("rb")
+        tls_wfile = tls_sock.makefile("wb")
+        try:
+            while True:
+                req = _read_request(tls_rfile)
+                if req is None:
+                    break
+                upstream_url = f"https://{hostname}{req.path}"
+                self._process_and_respond(
+                    session=session,
+                    req=req,
+                    wfile=tls_wfile,
+                    upstream_url=upstream_url,
+                    upstream_hostname=hostname,
+                    upstream_port=remote_port,
+                    upstream_path=req.path,
+                    scheme="https",
+                )
+        finally:
+            for f in (tls_rfile, tls_wfile):
                 try:
-                    dst.close()
+                    f.close()
                 except Exception:
                     pass
+            _close_quietly(tls_sock)
 
-        await asyncio.gather(
-            _relay(client_reader, upstream_writer),
-            _relay(upstream_reader, client_writer),
-        )
-
-    def _handle_connect_blocking(
-        self,
-        raw_sock,
-        ssl_ctx: ssl.SSLContext,
-        hostname: str,
-        remote_port: int,
-        session: SessionInfo,
+    def _connect_passthrough(
+        self, client_sock: socket.socket, hostname: str, port: int,
     ) -> None:
-        """Handle a CONNECT tunnel using blocking I/O in a thread."""
-        import http.client
-
-        raw_sock.setblocking(True)
+        """Tunnel raw bytes through to non-LLM hosts without inspection."""
         try:
-            ssl_sock = ssl_ctx.wrap_socket(raw_sock, server_side=True)
-        except (ssl.SSLError, ConnectionError, OSError) as exc:
-            logger.warning("TLS handshake failed for %s: %s", hostname, exc)
-            raw_sock.close()
-            return
-
-        try:
-            rfile = ssl_sock.makefile("rb")
-            wfile = ssl_sock.makefile("wb")
-
-            while True:
-                request_line = rfile.readline()
-                if not request_line:
-                    break
-                line = request_line.decode("utf-8", errors="replace").strip()
-                if not line:
-                    break
-
-                parts = line.split(" ", 2)
-                if len(parts) < 2:
-                    break
-                method, path = parts[0], parts[1]
-
-                headers: Dict[str, str] = {}
-                while True:
-                    hdr = rfile.readline()
-                    if hdr in (b"\r\n", b"\n", b""):
-                        break
-                    decoded = hdr.decode("utf-8", errors="replace").strip()
-                    if ":" in decoded:
-                        k, v = decoded.split(":", 1)
-                        headers[k.strip().lower()] = v.strip()
-
-                content_length = int(headers.get("content-length", "0"))
-                body = rfile.read(content_length) if content_length > 0 else b""
-
-                try:
-                    request_body = json.loads(body) if body else {}
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    request_body = {}
-
-                upstream_url = f"https://{hostname}{path}"
-                is_streaming = _is_streaming_request(request_body, path)
-
-                # Cache check.
-                if self._cache is not None and request_body:
-                    cache_key = _make_cache_key(request_body)
-                    entry = self._cache.get(cache_key)
-                    if entry is not None:
-                        if is_streaming:
-                            self._record_streaming_call(
-                                session=session,
-                                request_body=request_body,
-                                raw_sse=entry.response_bytes,
-                                request_url=upstream_url,
-                                latency=entry.latency_seconds,
-                                cached=True,
-                            )
-                        else:
-                            self._record_call(
-                                session=session,
-                                request_body=request_body,
-                                response_body_bytes=entry.response_bytes,
-                                request_url=upstream_url,
-                                latency=entry.latency_seconds,
-                                cached=True,
-                            )
-                        wfile.write(
-                            _build_http_response(
-                                200, entry.response_headers, entry.response_bytes,
-                            )
-                        )
-                        wfile.flush()
-                        continue
-
-                fwd_headers = {
-                    k: v
-                    for k, v in headers.items()
-                    if k not in _HOP_BY_HOP and k != "accept-encoding"
-                }
-                fwd_headers["host"] = hostname
-
-                t0 = time.monotonic()
-                try:
-                    conn = http.client.HTTPSConnection(
-                        hostname, remote_port, timeout=120
-                    )
-                    conn.request(method, path, body=body or None, headers=fwd_headers)
-                    resp = conn.getresponse()
-                    resp_status = resp.status
-                    resp_headers = {k.lower(): v for k, v in resp.getheaders()}
-                    resp_body = resp.read()
-                    conn.close()
-                except Exception as exc:
-                    latency = time.monotonic() - t0
-                    logger.warning(
-                        "Upstream request to %s failed: %s", upstream_url, exc
-                    )
-                    # Record the failed attempt for metrics.
-                    self._record_call(
-                        session=session,
-                        request_body=request_body,
-                        response_body_bytes=None,
-                        request_url=upstream_url,
-                        latency=latency,
-                        cached=False,
-                        status_code=0,
-                        error=str(exc),
-                    )
-                    error_body = json.dumps({"error": str(exc)}).encode()
-                    wfile.write(_build_http_response(502, {}, error_body))
-                    wfile.flush()
-                    continue
-                latency = time.monotonic() - t0
-
-                # Always record — 2xx, 4xx, 5xx all count toward cost/latency.
-                if is_streaming and resp_status == 200:
-                    self._record_streaming_call(
-                        session=session,
-                        request_body=request_body,
-                        raw_sse=resp_body,
-                        request_url=upstream_url,
-                        latency=latency,
-                    )
-                else:
-                    self._record_call(
-                        session=session,
-                        request_body=request_body,
-                        response_body_bytes=resp_body,
-                        request_url=upstream_url,
-                        latency=latency,
-                        cached=False,
-                        status_code=resp_status,
-                        error=None if resp_status == 200 else f"HTTP {resp_status}",
-                    )
-                if resp_status == 200 and self._cache is not None and request_body:
-                    cache_key = _make_cache_key(request_body)
-                    self._cache.put(
-                        cache_key,
-                        CacheEntry(
-                            response_bytes=resp_body,
-                            response_headers=dict(resp_headers),
-                            latency_seconds=latency,
-                        ),
-                    )
-
-                safe_headers = {
-                    k: v
-                    for k, v in resp_headers.items()
-                    if k not in ("transfer-encoding", "content-encoding")
-                }
-                wfile.write(_build_http_response(resp_status, safe_headers, resp_body))
-                wfile.flush()
-
-        except (ConnectionError, OSError, BrokenPipeError):
-            pass
-        finally:
+            upstream = socket.create_connection((hostname, port), timeout=30)
+        except Exception as exc:
             try:
-                ssl_sock.close()
+                client_sock.sendall(f"HTTP/1.1 502 Bad Gateway\r\n\r\n{exc}".encode())
             except Exception:
                 pass
+            return
+
+        try:
+            client_sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            _bidirectional_relay(client_sock, upstream)
+        finally:
+            _close_quietly(upstream)
 
     # ==================================================================
-    # DIRECT MODE
+    # Direct mode
     # ==================================================================
 
-    async def _handle_direct(
-        self,
-        session: SessionInfo,
-        first_line: bytes,
-        reader: asyncio.StreamReader,
-        writer: asyncio.StreamWriter,
+    def _direct_request_loop(
+        self, rfile: BinaryIO, wfile: BinaryIO, first_line: bytes, session: SessionInfo,
     ) -> None:
-        """Handle a plaintext HTTP request (direct mode from httpx patch)."""
-        line = first_line.decode("utf-8", errors="replace").strip()
-        parts = line.split(" ", 2)
-        if len(parts) < 2:
-            writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-            await writer.drain()
-            return
-
-        method = parts[0]
-        raw_path = parts[1]  # e.g. /v1/chat/completions
-
-        # Read headers.
-        headers: Dict[str, str] = {}
+        """Handle plaintext direct-mode requests, looping for keep-alive."""
+        pending_first_line: Optional[bytes] = first_line
         while True:
-            header_line = await reader.readline()
-            if header_line in (b"\r\n", b"\n", b""):
-                break
-            decoded = header_line.decode("utf-8", errors="replace").strip()
-            if ":" in decoded:
-                key, val = decoded.split(":", 1)
-                headers[key.strip().lower()] = val.strip()
-
-        # Read body.
-        content_length = int(headers.get("content-length", "0"))
-        body = b""
-        if content_length > 0:
-            body = await reader.readexactly(content_length)
-
-        # Parse body.
-        try:
-            request_body = json.loads(body) if body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            request_body = {}
-
-        is_streaming = _is_streaming_request(request_body, raw_path)
-
-        # Resolve upstream target.
-        try:
-            target_base, upstream_path = resolve_target(
-                raw_path, headers, self._providers,
-            )
-        except ValueError as exc:
-            resp = json.dumps({"error": str(exc)}).encode()
-            writer.write(
-                _build_http_response(502, {"content-type": "application/json"}, resp)
-            )
-            await writer.drain()
-            return
-
-        upstream_url = target_base.rstrip("/") + upstream_path
-
-        # Cache check.
-        if self._cache is not None and request_body:
-            cache_key = _make_cache_key(request_body)
-            entry = self._cache.get(cache_key)
-            if entry is not None:
-                if is_streaming:
-                    self._record_streaming_call(
-                        session=session,
-                        request_body=request_body,
-                        raw_sse=entry.response_bytes,
-                        request_url=upstream_url,
-                        latency=entry.latency_seconds,
-                        cached=True,
-                    )
-                else:
-                    self._record_call(
-                        session=session,
-                        request_body=request_body,
-                        response_body_bytes=entry.response_bytes,
-                        request_url=upstream_url,
-                        latency=entry.latency_seconds,
-                        cached=True,
-                    )
-                resp_headers = {
-                    k: v
-                    for k, v in entry.response_headers.items()
-                    if k.lower() not in ("content-encoding", "transfer-encoding")
-                }
-                writer.write(
-                    _build_http_response(200, resp_headers, entry.response_bytes)
-                )
-                await writer.drain()
+            req = _read_request(rfile, first_line=pending_first_line)
+            pending_first_line = None
+            if req is None:
                 return
 
-        # Build upstream headers.
-        fwd_headers: Dict[str, str] = {}
-        for k, v in headers.items():
-            if k not in _HOP_BY_HOP:
-                fwd_headers[k] = v
+            try:
+                base, upstream_path = self._registry.resolve_target(
+                    req.path, req.headers,
+                )
+            except ValueError as exc:
+                _write_response(
+                    wfile,
+                    502,
+                    {"content-type": "application/json"},
+                    json.dumps({"error": str(exc)}).encode(),
+                )
+                continue
 
-        # Forward request.
+            base_url = urlparse(base)
+            scheme = base_url.scheme or "https"
+            hostname = base_url.hostname or ""
+            port = base_url.port or (443 if scheme == "https" else 80)
+            self._process_and_respond(
+                session=session,
+                req=req,
+                wfile=wfile,
+                upstream_url=base.rstrip("/") + upstream_path,
+                upstream_hostname=hostname,
+                upstream_port=port,
+                upstream_path=upstream_path,
+                scheme=scheme,
+            )
+
+    # ==================================================================
+    # Shared request lifecycle
+    # ==================================================================
+
+    def _process_and_respond(
+        self,
+        *,
+        session: SessionInfo,
+        req: _Request,
+        wfile: BinaryIO,
+        upstream_url: str,
+        upstream_hostname: str,
+        upstream_port: int,
+        upstream_path: str,
+        scheme: str,
+    ) -> None:
+        """Cache check → forward → record → respond.
+
+        Used by both direct and CONNECT modes once their request is parsed.
+        """
+        is_streaming = is_streaming_request(req.json_body, req.path)
+
+        # 1. Cache.
+        if self._cache is not None and req.json_body:
+            cache_key = _make_cache_key(req.json_body)
+            entry = self._cache.get(cache_key)
+            if entry is not None:
+                self._record(
+                    session,
+                    req,
+                    entry.response_bytes,
+                    upstream_url,
+                    entry.latency_seconds,
+                    cached=True,
+                    is_streaming=is_streaming,
+                )
+                _write_response(
+                    wfile,
+                    200,
+                    _safe_response_headers(entry.response_headers),
+                    entry.response_bytes,
+                )
+                return
+
+        # 2. Forward.
+        fwd_headers = _build_forward_headers(
+            req.headers, upstream_hostname, upstream_port
+        )
         t0 = time.monotonic()
         try:
-            status, resp_headers, resp_body = await _forward_https(
-                method, upstream_url, fwd_headers, body, is_streaming,
+            status, resp_headers, resp_body = _forward(
+                method=req.method,
+                scheme=scheme,
+                hostname=upstream_hostname,
+                port=upstream_port,
+                path=upstream_path,
+                headers=fwd_headers,
+                body=req.body,
             )
         except Exception as exc:
             latency = time.monotonic() - t0
-            logger.warning("Upstream request failed: %s", exc)
-            # Record the failed attempt so latency / error counts show up in metrics.
-            self._record_call(
-                session=session,
-                request_body=request_body,
-                response_body_bytes=None,
-                request_url=upstream_url,
-                latency=latency,
+            logger.warning("upstream %s failed: %s", upstream_url, exc)
+            self._record(
+                session,
+                req,
+                None,
+                upstream_url,
+                latency,
                 cached=False,
+                is_streaming=is_streaming,
                 status_code=0,
                 error=str(exc),
             )
-            resp = json.dumps({"error": f"upstream error: {exc}"}).encode()
-            writer.write(
-                _build_http_response(502, {"content-type": "application/json"}, resp)
+            _write_response(
+                wfile,
+                502,
+                {"content-type": "application/json"},
+                json.dumps({"error": f"upstream error: {exc}"}).encode(),
             )
-            await writer.drain()
             return
         latency = time.monotonic() - t0
 
-        if is_streaming:
-            writer.write(_build_http_response(status, resp_headers, resp_body))
-            await writer.drain()
-            self._record_streaming_call(
-                session=session,
-                request_body=request_body,
-                raw_sse=resp_body,
-                request_url=upstream_url,
-                latency=latency,
-            )
-        else:
-            # Always record — 2xx, 4xx, 5xx all count toward cost/latency.
-            self._record_call(
-                session=session,
-                request_body=request_body,
-                response_body_bytes=resp_body,
-                request_url=upstream_url,
-                latency=latency,
-                cached=False,
-                status_code=status,
-                error=None if status == 200 else f"HTTP {status}",
-            )
-            if status == 200 and self._cache is not None and request_body:
-                cache_key = _make_cache_key(request_body)
-                self._cache.put(
-                    cache_key,
-                    CacheEntry(
-                        response_bytes=resp_body,
-                        response_headers=dict(resp_headers),
-                        latency_seconds=latency,
-                    ),
-                )
+        # 3. Record (every status — 2xx, 4xx, 5xx all count as work).
+        self._record(
+            session,
+            req,
+            resp_body,
+            upstream_url,
+            latency,
+            cached=False,
+            is_streaming=is_streaming,
+            status_code=status,
+            error=None if status == 200 else f"HTTP {status}",
+        )
 
-            safe_headers = {
-                k: v
-                for k, v in resp_headers.items()
-                if k.lower() not in ("transfer-encoding", "content-encoding")
-            }
-            writer.write(_build_http_response(status, safe_headers, resp_body))
-            await writer.drain()
+        # 4. Cache successful responses.
+        if status == 200 and self._cache is not None and req.json_body:
+            self._cache.put(
+                _make_cache_key(req.json_body),
+                CacheEntry(
+                    response_bytes=resp_body,
+                    response_headers=dict(resp_headers),
+                    latency_seconds=latency,
+                ),
+            )
+
+        # 5. Respond.
+        _write_response(
+            wfile, status, _safe_response_headers(resp_headers), resp_body,
+        )
 
     # ------------------------------------------------------------------
-    # Recording helpers
+    # Recording
     # ------------------------------------------------------------------
 
-    def _record_call(
+    def _record(
         self,
-        session: Any,
-        request_body: dict,
-        response_body_bytes: Optional[bytes],
+        session: SessionInfo,
+        req: _Request,
+        response_body: Optional[bytes],
         request_url: str,
         latency: float,
+        *,
         cached: bool,
+        is_streaming: bool,
         status_code: int = 200,
         error: Optional[str] = None,
     ) -> None:
-        """Record a ``CallRecord`` for any outcome (success or failure).
+        """Build a ``CallRecord`` and hand it to the session manager."""
+        usage = None
+        parse_err: Optional[str] = None
 
-        Token counts are populated if the response body parses and contains
-        a ``usage`` object; otherwise they default to 0.  Failed requests
-        (non-200, connection errors) are still recorded so cost/latency
-        metrics reflect real work done.
-        """
-        prompt_tokens = 0
-        completion_tokens = 0
-        resp_body: Dict[str, Any] = {}
-        model: Optional[str] = request_body.get("model")
-        usage_extracted = False
-        parse_failure_reason: Optional[str] = None
-
-        if response_body_bytes:
-            try:
-                parsed_body = json.loads(response_body_bytes)
-            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-                parse_failure_reason = (
-                    f"response body is not valid JSON ({type(exc).__name__}); "
-                    f"first 200 bytes: {response_body_bytes[:200]!r}"
-                )
-            else:
-                if isinstance(parsed_body, dict):
-                    resp_body = parsed_body
-                    parsed = _parse_usage(parsed_body)
-                    if parsed is not None:
-                        prompt_tokens = parsed["prompt_tokens"]
-                        completion_tokens = parsed["completion_tokens"]
-                        model = model or parsed["model"]
-                        usage_extracted = True
-                    else:
-                        parse_failure_reason = (
-                            "response body is a JSON object but has no "
-                            "recognized usage/model fields "
-                            "(expected one of: usage, usageMetadata, "
-                            "input_tokens/output_tokens, "
-                            "prompt_tokens/completion_tokens, "
-                            "promptTokenCount/candidatesTokenCount). "
-                            f"keys present: {sorted(parsed_body.keys())[:10]}"
-                        )
-                elif isinstance(parsed_body, list):
-                    # Gemini's `streamGenerateContent` (without alt=sse)
-                    # returns a JSON array of partial chunks; the final
-                    # one carries `usageMetadata`.
-                    for chunk in parsed_body:
-                        if not isinstance(chunk, dict):
-                            continue
-                        parsed = _parse_usage(chunk)
-                        if parsed is None:
-                            continue
-                        if parsed["prompt_tokens"] > prompt_tokens:
-                            prompt_tokens = parsed["prompt_tokens"]
-                        if parsed["completion_tokens"] > completion_tokens:
-                            completion_tokens = parsed["completion_tokens"]
-                        model = model or parsed["model"]
-                        usage_extracted = True
-                    if parsed_body and isinstance(parsed_body[-1], dict):
-                        resp_body = parsed_body[-1]
-                    if not usage_extracted:
-                        parse_failure_reason = (
-                            f"response body is a JSON array of {len(parsed_body)} "
-                            "items but none carried recognized usage/model fields"
-                        )
-                else:
-                    parse_failure_reason = (
-                        f"response body is JSON but neither object nor array "
-                        f"(got {type(parsed_body).__name__})"
-                    )
+        if response_body is None:
+            # Failure path — caller already supplied the error message.
+            pass
+        elif is_streaming and status_code == 200:
+            usage, parse_err = extract_usage_streaming(
+                response_body, req.json_body, request_url,
+            )
         else:
-            parse_failure_reason = "response body was empty"
+            usage, parse_err = extract_usage(response_body)
 
-        # Loud surfacing of token-extraction failures — silent fallbacks
-        # mask real proxy gaps (e.g. unrecognized provider response shapes).
-        # Only flag on successful (200) calls; non-2xx records already have
-        # an HTTP error attached.
-        if (
-            not usage_extracted
-            and status_code == 200
-            and not error
-            and parse_failure_reason is not None
-        ):
-            error = (
-                f"agentopt proxy could not extract token usage: "
-                f"{parse_failure_reason}. URL={request_url}"
-            )
-            logger.warning(
-                "agentopt: %s call to %s succeeded (200) but token usage "
-                "could not be extracted — %s",
-                model or "<unknown>",
-                request_url,
-                parse_failure_reason,
-            )
-            if not model:
-                model = PARSE_FAILED_MODEL
-        elif not model:
-            # Fallback for non-200 / pre-200 cases where we never learned
-            # the model — keep the legacy "unknown" so result summaries
-            # don't break, but only when an explicit error is already set.
-            model = "unknown"
-
-        record = CallRecord(
-            data_id=session.data_id,
-            combo_id=session.combo_id,
-            agent_id=session.agent_id,
-            model=model,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            latency_seconds=latency,
-            request_url=request_url,
-            request_body=request_body,
-            response_body=resp_body,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            cached=cached,
-            status_code=status_code,
-            error=error,
-        )
-        self.session_manager.add_record(session.session_id, record)
-
-    def _record_streaming_call(
-        self,
-        session: Any,
-        request_body: dict,
-        raw_sse: bytes,
-        request_url: str,
-        latency: float,
-        cached: bool = False,
-    ) -> None:
-        """Best-effort usage extraction from accumulated SSE data."""
-        text = raw_sse.decode("utf-8", errors="replace")
-        model: Optional[str] = request_body.get("model")
+        model: Optional[str] = req.json_body.get("model")
         prompt_tokens = 0
         completion_tokens = 0
-        usage_extracted = False
-        sse_lines_seen = 0
+        resp_body_for_record: Dict[str, Any] = {}
+        if usage is not None:
+            model = model or usage.model
+            prompt_tokens = usage.prompt_tokens
+            completion_tokens = usage.completion_tokens
+            resp_body_for_record = usage.response_body
 
-        # Scan all SSE lines to find usage from both message_start (input)
-        # and message_delta (output).  Anthropic splits usage across events:
-        #   message_start  → message.usage (input_tokens, cache_read/creation)
-        #   message_delta  → usage (output_tokens, plus input echo)
-        for line in text.splitlines():
-            if not line.startswith("data: "):
-                continue
-            sse_lines_seen += 1
-            payload = line[len("data: ") :]
-            if payload.strip() == "[DONE]":
-                continue
-            try:
-                chunk = json.loads(payload)
-            except json.JSONDecodeError:
-                continue
-
-            # OpenAI top-level `usage`; Anthropic message.usage on message_start;
-            # Gemini top-level `usageMetadata` on the final chunk.
-            usage = chunk.get("usage") or chunk.get("usageMetadata")
-            msg = chunk.get("message")
-            if isinstance(msg, dict) and msg.get("usage"):
-                usage = usage or msg["usage"]
-
-            if usage:
-                inp = (
-                    (
-                        usage.get("prompt_tokens")
-                        or usage.get("input_tokens")
-                        or usage.get("promptTokenCount")
-                        or 0
-                    )
-                    + (usage.get("cache_read_input_tokens") or 0)
-                    + (usage.get("cache_creation_input_tokens") or 0)
-                )
-                out = (
-                    usage.get("completion_tokens")
-                    or usage.get("output_tokens")
-                    or _gemini_completion_tokens(usage)
-                )
-                if inp > prompt_tokens:
-                    prompt_tokens = inp
-                if out > completion_tokens:
-                    completion_tokens = out
-                model = model or chunk.get("model") or chunk.get("modelVersion")
-                if inp or out:
-                    usage_extracted = True
-
-        # Surface streaming-parse failures explicitly. The OpenAI
-        # `stream_options.include_usage` quirk gets a more actionable
-        # message; everything else gets the generic diagnostic.
-        record_error: Optional[str] = None
-        if not usage_extracted:
-            if (
-                _is_openai_compatible_url(request_url)
-                and request_body.get("stream") is True
-                and not _has_include_usage(request_body)
-            ):
-                detail = (
-                    "OpenAI-compatible streams omit usage by default — set "
-                    '`stream_options={"include_usage": True}` on the request '
-                    "to enable token tracking. (Anthropic streams are unaffected.)"
-                )
-            elif sse_lines_seen == 0:
-                detail = (
-                    f"streaming response had no `data: ...` SSE frames "
-                    f"(body length={len(raw_sse)} bytes, "
-                    f"first 200 bytes={raw_sse[:200]!r}). "
-                    "If this is a non-SSE chunked stream (e.g. Gemini's "
-                    "`streamGenerateContent` without `alt=sse`), the "
-                    "non-streaming code path handles JSON arrays; "
-                    "otherwise this provider's streaming format may need "
-                    "explicit support in the proxy parser."
-                )
-            else:
-                detail = (
-                    f"streaming response had {sse_lines_seen} SSE frames "
-                    "but none carried recognized usage/model fields"
-                )
-            record_error = f"agentopt proxy could not extract token usage: {detail}"
-            hostname = urlparse(request_url).hostname or request_url
-            if hostname not in self._openai_stream_usage_warned:
-                self._openai_stream_usage_warned.add(hostname)
-                logger.warning(
-                    "agentopt: streaming call to %s yielded no token usage — %s",
-                    hostname,
-                    detail,
-                )
+        record_error = error
+        # Loud surfacing of token-extraction failures on otherwise-successful
+        # calls — silent zeros mask real proxy gaps.
+        if usage is None and status_code == 200 and not error and parse_err is not None:
+            record_error = (
+                f"agentopt proxy could not extract token usage: {parse_err}. "
+                f"URL={request_url}"
+            )
+            self._maybe_warn(request_url, parse_err, model)
             if not model:
                 model = PARSE_FAILED_MODEL
         elif not model:
             model = "unknown"
 
-        record = CallRecord(
-            data_id=session.data_id,
-            combo_id=session.combo_id,
-            agent_id=session.agent_id,
-            model=model,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            latency_seconds=latency,
-            request_url=request_url,
-            request_body=request_body,
-            response_body={},
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            cached=cached,
-            error=record_error,
+        self.session_manager.add_record(
+            session.session_id,
+            CallRecord(
+                data_id=session.data_id,
+                combo_id=session.combo_id,
+                agent_id=session.agent_id,
+                model=model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                latency_seconds=latency,
+                request_url=request_url,
+                request_body=req.json_body,
+                response_body=resp_body_for_record,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                cached=cached,
+                status_code=status_code,
+                error=record_error,
+            ),
         )
-        self.session_manager.add_record(session.session_id, record)
+
+    def _maybe_warn(self, request_url: str, reason: str, model: Optional[str],) -> None:
+        host = urlparse(request_url).hostname or request_url
+        if host in self._stream_warned_hosts:
+            return
+        self._stream_warned_hosts.add(host)
+        logger.warning(
+            "agentopt: %s call to %s succeeded but token usage could not be "
+            "extracted — %s",
+            model or "<unknown>",
+            request_url,
+            reason,
+        )
 
 
-# ======================================================================
-# HTTP helpers
-# ======================================================================
+# ---------------------------------------------------------------------------
+# HTTP parsing / forwarding / serialization helpers
+# ---------------------------------------------------------------------------
 
 
-def _build_http_response(status: int, headers: Dict[str, str], body: bytes,) -> bytes:
-    """Build a raw HTTP/1.1 response as bytes."""
-    from http import HTTPStatus
+def _read_request(
+    rfile: BinaryIO, first_line: Optional[bytes] = None,
+) -> Optional[_Request]:
+    """Parse one HTTP/1.1 request from a binary file-like.
 
+    Returns ``None`` on EOF or a malformed request line.
+    """
+    if first_line is None:
+        first_line = rfile.readline()
+    if not first_line:
+        return None
+
+    line = first_line.decode("utf-8", errors="replace").strip()
+    parts = line.split(" ", 2)
+    if len(parts) < 2:
+        return None
+    method, path = parts[0], parts[1]
+
+    headers: Dict[str, str] = {}
+    while True:
+        h = rfile.readline()
+        if h in (b"\r\n", b"\n", b""):
+            break
+        decoded = h.decode("utf-8", errors="replace").strip()
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    content_length = int(headers.get("content-length", "0") or "0")
+    body = rfile.read(content_length) if content_length > 0 else b""
+
+    json_body: Dict[str, Any] = {}
+    if body:
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict):
+                json_body = parsed
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+    return _Request(
+        method=method, path=path, headers=headers, body=body, json_body=json_body,
+    )
+
+
+def _build_forward_headers(
+    incoming: Dict[str, str], hostname: str, port: int,
+) -> Dict[str, str]:
+    """Strip hop-by-hop + accept-encoding, set Host."""
+    fwd = {k: v for k, v in incoming.items() if k not in _HOP_BY_HOP}
+    # accept-encoding stripped so we don't get gzipped responses we'd have
+    # to decode just to extract usage.
+    fwd.pop("accept-encoding", None)
+    if port in (80, 443):
+        fwd["host"] = hostname
+    else:
+        fwd["host"] = f"{hostname}:{port}"
+    return fwd
+
+
+def _forward(
+    *,
+    method: str,
+    scheme: str,
+    hostname: str,
+    port: int,
+    path: str,
+    headers: Dict[str, str],
+    body: bytes,
+) -> Tuple[int, Dict[str, str], bytes]:
+    """Forward one HTTP/HTTPS request synchronously and return the full response."""
+    if scheme == "https":
+        conn = http.client.HTTPSConnection(hostname, port, timeout=120)
+    else:
+        conn = http.client.HTTPConnection(hostname, port, timeout=120)
     try:
-        status_text = HTTPStatus(status).phrase
+        conn.request(method, path, body=body or None, headers=headers)
+        resp = conn.getresponse()
+        resp_headers = {k.lower(): v for k, v in resp.getheaders()}
+        return resp.status, resp_headers, resp.read()
+    finally:
+        conn.close()
+
+
+def _build_response(status: int, headers: Dict[str, str], body: bytes,) -> bytes:
+    """Serialize an HTTP/1.1 response."""
+    try:
+        phrase = HTTPStatus(status).phrase
     except ValueError:
-        status_text = "Unknown"
-    lines: List[str] = [f"HTTP/1.1 {status} {status_text}"]
-    header_lower = {k.lower(): v for k, v in headers.items()}
-    if "content-length" not in header_lower:
-        headers["content-length"] = str(len(body))
-    for k, v in headers.items():
+        phrase = "Unknown"
+
+    out_headers = dict(headers)
+    if not any(k.lower() == "content-length" for k in out_headers):
+        out_headers["content-length"] = str(len(body))
+
+    lines = [f"HTTP/1.1 {status} {phrase}"]
+    for k, v in out_headers.items():
         lines.append(f"{k}: {v}")
     lines.append("")
     lines.append("")
     return "\r\n".join(lines).encode("utf-8") + body
 
 
-async def _forward_https(
-    method: str, url: str, headers: Dict[str, str], body: bytes, is_streaming: bool,
-) -> Tuple[int, Dict[str, str], bytes]:
-    """Forward an HTTP request to an upstream HTTPS URL."""
-    import aiohttp
+def _write_response(
+    wfile: BinaryIO, status: int, headers: Dict[str, str], body: bytes,
+) -> None:
+    wfile.write(_build_response(status, headers, body))
+    wfile.flush()
 
-    # Keep trust_env=True so aiohttp picks up user's SSL_CERT_FILE /
-    # REQUESTS_CA_BUNDLE (needed behind corporate MITM).  Override proxy
-    # per-request to None so our own HTTPS_PROXY doesn't loop back.
-    async with aiohttp.ClientSession() as session:
-        async with session.request(
-            method=method,
-            url=url,
-            headers=headers,
-            data=body if body else None,
-            proxy=None,
-        ) as resp:
-            resp_body = await resp.read()
-            resp_headers = {k: v for k, v in resp.headers.items()}
-            return resp.status, resp_headers, resp_body
+
+def _safe_response_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Strip headers that don't survive proxy retransmission."""
+    return {
+        k: v
+        for k, v in headers.items()
+        if k.lower() not in ("transfer-encoding", "content-encoding")
+    }
+
+
+def _bidirectional_relay(a: socket.socket, b: socket.socket) -> None:
+    """Pump bytes between two sockets until either side closes."""
+
+    def relay(src: socket.socket, dst: socket.socket) -> None:
+        try:
+            while True:
+                data = src.recv(65536)
+                if not data:
+                    break
+                dst.sendall(data)
+        except Exception:
+            pass
+        finally:
+            try:
+                dst.shutdown(socket.SHUT_WR)
+            except Exception:
+                pass
+
+    t1 = threading.Thread(target=relay, args=(a, b), daemon=True)
+    t2 = threading.Thread(target=relay, args=(b, a), daemon=True)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+
+def _close_quietly(sock: Any) -> None:
+    try:
+        sock.close()
+    except Exception:
+        pass

--- a/src/agentopt/proxy/server.py
+++ b/src/agentopt/proxy/server.py
@@ -52,6 +52,7 @@ from .providers import (
 from .session import SessionInfo, SessionManager
 from .usage import (
     PARSE_FAILED_MODEL,
+    UsageExtractionError,
     extract_usage,
     extract_usage_streaming,
     is_streaming_request,
@@ -528,12 +529,16 @@ class ProxyServer:
         if response_body is None:
             # Failure path — caller already supplied the error message.
             pass
-        elif is_streaming and status_code == 200:
-            usage, parse_err = extract_usage_streaming(
-                response_body, req.json_body, request_url,
-            )
         else:
-            usage, parse_err = extract_usage(response_body)
+            try:
+                if is_streaming and status_code == 200:
+                    usage = extract_usage_streaming(
+                        response_body, req.json_body, request_url,
+                    )
+                else:
+                    usage = extract_usage(response_body)
+            except UsageExtractionError as exc:
+                parse_err = str(exc)
 
         model: Optional[str] = req.json_body.get("model")
         prompt_tokens = 0
@@ -626,7 +631,7 @@ def _read_request(
             k, v = decoded.split(":", 1)
             headers[k.strip().lower()] = v.strip()
 
-    content_length = int(headers.get("content-length", "0") or "0")
+    content_length = _parse_content_length(headers, method)
     body = rfile.read(content_length) if content_length > 0 else b""
 
     json_body: Dict[str, Any] = {}
@@ -641,6 +646,36 @@ def _read_request(
     return _Request(
         method=method, path=path, headers=headers, body=body, json_body=json_body,
     )
+
+
+def _parse_content_length(headers: Dict[str, str], method: str) -> int:
+    """Strict Content-Length parse.
+
+    HTTP framing must not be guessed.  Silently defaulting to 0 on a missing
+    or malformed header would either truncate the request body (sending a
+    broken request upstream) or desynchronize the keep-alive parser, since
+    the unread body bytes would be misread as the next request line.
+
+    Raises ``ValueError`` if:
+    * the header is absent on a body-bearing method (POST/PUT/PATCH)
+    * the value isn't a non-negative integer
+    """
+    raw = headers.get("content-length")
+    if raw is None:
+        if method.upper() in ("POST", "PUT", "PATCH"):
+            raise ValueError(
+                f"{method} request is missing Content-Length header "
+                f"(header keys present: {sorted(headers)})"
+            )
+        return 0
+
+    try:
+        n = int(raw.strip())
+    except ValueError as exc:
+        raise ValueError(f"Content-Length is not an integer: {raw!r}") from exc
+    if n < 0:
+        raise ValueError(f"Content-Length is negative: {n}")
+    return n
 
 
 def _build_forward_headers(

--- a/src/agentopt/proxy/tracker.py
+++ b/src/agentopt/proxy/tracker.py
@@ -140,13 +140,10 @@ class LLMTracker:
         is fully safe — each subprocess gets its own ``HTTPS_PROXY``.
         """
         assert self._server is not None, "call tracker.start() first"
-        entry = self._server._session_listeners.get(session.session_id)
-        assert entry is not None, f"no port for session {session.session_id}"
-        _, port = entry
+        port = self._server.get_session_port(session.session_id)
         ca_bundle = self._ca.ca_bundle_path
-        proxy_url = f"http://127.0.0.1:{port}"
         return {
-            "HTTPS_PROXY": proxy_url,
+            "HTTPS_PROXY": f"http://127.0.0.1:{port}",
             "SSL_CERT_FILE": ca_bundle,
             "REQUESTS_CA_BUNDLE": ca_bundle,
             "NODE_EXTRA_CA_CERTS": ca_bundle,

--- a/src/agentopt/proxy/tracker.py
+++ b/src/agentopt/proxy/tracker.py
@@ -8,7 +8,12 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from .cache import ResponseCache
 from .certs import CertificateAuthority
-from .interceptor import _session_port_var, install_redirect, uninstall_redirect
+from .interceptor import (
+    _session_port_var,
+    install_redirect,
+    register_extra_llm_paths,
+    uninstall_redirect,
+)
 from .models import CallRecord
 from .server import ProxyServer
 from .session import SessionInfo
@@ -156,9 +161,18 @@ class LLMTracker:
     def register_provider(
         self, name: str, base_url: str, path_patterns: tuple,
     ) -> None:
-        """Add or replace a provider in the proxy's registry."""
+        """Add or replace a provider in the proxy's registry.
+
+        Updates three places at once so the new provider works for both
+        agent shapes:
+        * the proxy's per-instance registry (direct-mode resolution)
+        * the proxy's CONNECT-mode intercept-host set (subprocess agents)
+        * the in-process httpx patch's path-pattern set, so direct-mode
+          calls to the new provider get redirected at all.
+        """
         assert self._server is not None, "call tracker.start() first"
         self._server.register_provider(name, base_url, path_patterns)
+        register_extra_llm_paths(path_patterns)
 
     # ------------------------------------------------------------------
     # Cache management

--- a/src/agentopt/proxy/usage.py
+++ b/src/agentopt/proxy/usage.py
@@ -7,10 +7,10 @@ Three input shapes are handled:
   (returned without ``alt=sse``).
 * SSE stream — ``data: {...}`` frames from any provider's streaming API.
 
-All extraction returns ``(ParsedUsage | None, parse_failure_reason | None)``.
-The proxy uses the failure reason to attach a structured error to the
-``CallRecord`` so a successful call with unparseable usage isn't silently
-reported as zero tokens.
+Failure mode: the extractors raise :class:`UsageExtractionError` with a
+message describing exactly what was searched and what keys were present.
+No silent zeros — a successful HTTP call whose usage we can't parse is a
+proxy gap that should surface, not a 0-token record.
 """
 
 from __future__ import annotations
@@ -32,6 +32,20 @@ _OPENAI_COMPAT_PATHS = (
     "/v1/completions",
     "/chat/completions",
 )
+
+
+# Recognized token-count keys, in priority order.
+_PROMPT_KEYS = ("prompt_tokens", "input_tokens", "promptTokenCount")
+_COMPLETION_KEYS = ("completion_tokens", "output_tokens")
+_GEMINI_COMPLETION_KEYS = ("candidatesTokenCount", "thoughtsTokenCount")
+
+
+class UsageExtractionError(ValueError):
+    """Raised when token usage can't be parsed from an LLM response.
+
+    The exception message is suitable for attaching to a ``CallRecord.error``
+    so a proxy gap is visible without combing through logs.
+    """
 
 
 @dataclass(frozen=True)
@@ -81,47 +95,75 @@ def _gemini_completion_tokens(usage: dict) -> int:
     """Sum visible output and reasoning tokens for Gemini thinking models.
 
     Gemini reports ``candidatesTokenCount`` (visible) and
-    ``thoughtsTokenCount`` (reasoning) separately; both bill as output, so
-    callers want the sum.  Falls back to ``totalTokenCount - promptTokenCount``
-    if individual fields aren't broken out.
+    ``thoughtsTokenCount`` (reasoning) separately; both bill as output.
+    Falls back to ``totalTokenCount - promptTokenCount`` when individual
+    fields aren't broken out.
+
+    Raises :class:`UsageExtractionError` if no recognized completion field
+    is present.
     """
-    candidates = usage.get("candidatesTokenCount") or 0
-    thoughts = usage.get("thoughtsTokenCount") or 0
-    if candidates or thoughts:
-        return candidates + thoughts
+    candidates = usage.get("candidatesTokenCount")
+    thoughts = usage.get("thoughtsTokenCount")
+    if candidates is not None or thoughts is not None:
+        return (candidates or 0) + (thoughts or 0)
+
     total = usage.get("totalTokenCount")
-    prompt = usage.get("promptTokenCount") or 0
-    if isinstance(total, int) and total > prompt:
+    prompt = usage.get("promptTokenCount")
+    if isinstance(total, int) and isinstance(prompt, int) and total > prompt:
         return total - prompt
-    return 0
+
+    raise UsageExtractionError(
+        f"no Gemini completion-token field in usage dict — searched "
+        f"{list(_GEMINI_COMPLETION_KEYS)} (or totalTokenCount > "
+        f"promptTokenCount). keys present: {sorted(usage.keys())}"
+    )
 
 
 def _extract_usage_dict(usage: dict) -> Tuple[int, int]:
-    """``(prompt_tokens, completion_tokens)`` from any provider's usage dict."""
-    prompt = (
-        usage.get("prompt_tokens")
-        or usage.get("input_tokens")
-        or usage.get("promptTokenCount")
-        or 0
-    )
-    completion = (
-        usage.get("completion_tokens")
-        or usage.get("output_tokens")
-        or _gemini_completion_tokens(usage)
-    )
+    """Return ``(prompt_tokens, completion_tokens)`` from a usage dict.
+
+    Raises :class:`UsageExtractionError` if a prompt-style or completion-style
+    key cannot be found.  Both axes must be present — silent zero-fill would
+    mask broken responses.
+    """
+    prompt = next((usage[k] for k in _PROMPT_KEYS if k in usage), None)
+    if prompt is None:
+        raise UsageExtractionError(
+            f"no prompt-token field in usage dict — searched "
+            f"{list(_PROMPT_KEYS)}. keys present: {sorted(usage.keys())}"
+        )
+
+    completion = next((usage[k] for k in _COMPLETION_KEYS if k in usage), None)
+    if completion is None:
+        # Gemini's usageMetadata uses different keys.  This raises with
+        # its own diagnostic if neither standard nor Gemini fields match.
+        completion = _gemini_completion_tokens(usage)
+
     return prompt, completion
 
 
 def _parse_chunk(chunk: dict) -> Optional[ParsedUsage]:
-    """Pull usage from a single response object (any provider)."""
+    """Extract usage from one response object.
+
+    Returns ``None`` when the chunk has no usage section at all (a normal
+    state for, e.g., a Gemini chunk that's only carrying content).  Raises
+    :class:`UsageExtractionError` when usage IS present but its fields
+    can't be read — that's a real provider-shape mismatch.
+    """
     model = chunk.get("model") or chunk.get("modelVersion")
     usage = chunk.get("usage") or chunk.get("usageMetadata")
     msg = chunk.get("message")
     if not usage and isinstance(msg, dict):
         usage = msg.get("usage")
         model = model or msg.get("model")
-    if not model or not usage:
+    if not usage:
         return None
+    if not model:
+        raise UsageExtractionError(
+            f"usage dict present but no `model` / `modelVersion` field. "
+            f"chunk keys: {sorted(chunk.keys())}"
+        )
+
     prompt, completion = _extract_usage_dict(usage)
     return ParsedUsage(
         model=model,
@@ -136,51 +178,51 @@ def _parse_chunk(chunk: dict) -> Optional[ParsedUsage]:
 # ---------------------------------------------------------------------------
 
 
-def extract_usage(body_bytes: bytes,) -> Tuple[Optional[ParsedUsage], Optional[str]]:
+def extract_usage(body_bytes: bytes) -> ParsedUsage:
     """Parse usage from a non-streaming response body.
 
-    Returns ``(usage, parse_failure_reason)``: exactly one is non-None.
+    Raises :class:`UsageExtractionError` on any failure — empty body,
+    invalid JSON, unrecognized shape, or missing token-count keys.  The
+    exception message names exactly what was searched and what was found.
     """
     if not body_bytes:
-        return None, "response body was empty"
+        raise UsageExtractionError("response body was empty")
 
     try:
         parsed = json.loads(body_bytes)
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        return (
-            None,
-            (
-                f"response body is not valid JSON ({type(exc).__name__}); "
-                f"first 200 bytes: {body_bytes[:200]!r}"
-            ),
-        )
+        raise UsageExtractionError(
+            f"response body is not valid JSON ({type(exc).__name__}); "
+            f"first 200 bytes: {body_bytes[:200]!r}"
+        ) from exc
 
     if isinstance(parsed, dict):
         usage = _parse_chunk(parsed)
         if usage is None:
-            return (
-                None,
-                (
-                    "response body is a JSON object but has no recognized "
-                    "usage/model fields (expected one of: usage, usageMetadata, "
-                    "input_tokens/output_tokens, prompt_tokens/completion_tokens, "
-                    "promptTokenCount/candidatesTokenCount). "
-                    f"keys present: {sorted(parsed.keys())[:10]}"
-                ),
+            raise UsageExtractionError(
+                "response body is a JSON object but has no recognized "
+                "usage section (expected one of: usage, usageMetadata, "
+                "or message.usage). "
+                f"keys present: {sorted(parsed.keys())[:10]}"
             )
-        return usage, None
+        return usage
 
     if isinstance(parsed, list):
         # Gemini's streamGenerateContent without alt=sse returns a JSON
-        # array of partial chunks; usage is on the final chunk(s).
+        # array of partial chunks; usage typically lands on the final ones.
         best_model: Optional[str] = None
         best_prompt = 0
         best_completion = 0
         any_extracted = False
+        last_error: Optional[UsageExtractionError] = None
         for chunk in parsed:
             if not isinstance(chunk, dict):
                 continue
-            u = _parse_chunk(chunk)
+            try:
+                u = _parse_chunk(chunk)
+            except UsageExtractionError as exc:
+                last_error = exc
+                continue
             if u is None:
                 continue
             any_extracted = True
@@ -189,44 +231,41 @@ def extract_usage(body_bytes: bytes,) -> Tuple[Optional[ParsedUsage], Optional[s
                 best_prompt = u.prompt_tokens
             if u.completion_tokens > best_completion:
                 best_completion = u.completion_tokens
-        last_obj = parsed[-1] if parsed and isinstance(parsed[-1], dict) else {}
         if not any_extracted:
-            return (
-                None,
-                (
-                    f"response body is a JSON array of {len(parsed)} items but "
-                    "none carried recognized usage/model fields"
-                ),
+            detail = (
+                f" (last per-chunk error: {last_error})"
+                if last_error is not None
+                else ""
             )
-        return (
-            ParsedUsage(
-                model=best_model,
-                prompt_tokens=best_prompt,
-                completion_tokens=best_completion,
-                response_body=last_obj,
-            ),
-            None,
+            raise UsageExtractionError(
+                f"response body is a JSON array of {len(parsed)} items but "
+                f"none carried recognized usage/model fields{detail}"
+            )
+        last_obj = parsed[-1] if parsed and isinstance(parsed[-1], dict) else {}
+        return ParsedUsage(
+            model=best_model,
+            prompt_tokens=best_prompt,
+            completion_tokens=best_completion,
+            response_body=last_obj,
         )
 
-    return (
-        None,
-        (
-            f"response body is JSON but neither object nor array "
-            f"(got {type(parsed).__name__})"
-        ),
+    raise UsageExtractionError(
+        f"response body is JSON but neither object nor array "
+        f"(got {type(parsed).__name__})"
     )
 
 
 def extract_usage_streaming(
     raw_sse: bytes, request_body: dict, request_url: str,
-) -> Tuple[Optional[ParsedUsage], Optional[str]]:
+) -> ParsedUsage:
     """Parse token usage from accumulated SSE bytes.
 
-    Anthropic splits usage across events (``message_start`` carries
-    input, ``message_delta`` carries output), so we scan all frames and
-    take the max of each axis.
+    Anthropic splits usage across events (``message_start`` carries input,
+    ``message_delta`` carries output), so we scan all frames and take the
+    max of each axis.  Per-frame missing fields are NOT errors — only the
+    aggregate result is checked.
 
-    Returns ``(usage, parse_failure_reason)``: exactly one is non-None.
+    Raises :class:`UsageExtractionError` if no frame yielded usable usage.
     """
     text = raw_sse.decode("utf-8", errors="replace")
     prompt_tokens = 0
@@ -256,22 +295,10 @@ def extract_usage_streaming(
         if not usage:
             continue
 
-        # Anthropic counts cache_read/creation against input.
-        prompt_axis = (
-            (
-                usage.get("prompt_tokens")
-                or usage.get("input_tokens")
-                or usage.get("promptTokenCount")
-                or 0
-            )
-            + (usage.get("cache_read_input_tokens") or 0)
-            + (usage.get("cache_creation_input_tokens") or 0)
-        )
-        completion_axis = (
-            usage.get("completion_tokens")
-            or usage.get("output_tokens")
-            or _gemini_completion_tokens(usage)
-        )
+        # Per-chunk reads stay tolerant: a frame may legitimately carry
+        # only one direction (Anthropic message_start has input only).
+        # The aggregate is what's checked at the end.
+        prompt_axis, completion_axis = _streaming_chunk_axes(usage)
         if prompt_axis > prompt_tokens:
             prompt_tokens = prompt_axis
         if completion_axis > completion_tokens:
@@ -281,17 +308,14 @@ def extract_usage_streaming(
             found_usage = True
 
     if found_usage:
-        return (
-            ParsedUsage(
-                model=model,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                response_body={},
-            ),
-            None,
+        return ParsedUsage(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            response_body={},
         )
 
-    # Diagnose.
+    # No frame produced usage — diagnose with the most actionable message.
     if (
         is_openai_compatible_url(request_url)
         and request_body.get("stream") is True
@@ -317,4 +341,33 @@ def extract_usage_streaming(
             f"streaming response had {sse_lines_seen} SSE frames "
             "but none carried recognized usage/model fields"
         )
-    return None, reason
+    raise UsageExtractionError(reason)
+
+
+def _streaming_chunk_axes(usage: dict) -> Tuple[int, int]:
+    """Lenient per-chunk read for streaming.
+
+    Streaming chunks legitimately carry only one direction at a time, so
+    missing keys here fall through to ``0``.  The aggregate ``found_usage``
+    check in :func:`extract_usage_streaming` decides whether the *whole*
+    response was unparseable.
+    """
+    prompt_axis = (
+        (
+            usage.get("prompt_tokens")
+            or usage.get("input_tokens")
+            or usage.get("promptTokenCount")
+            or 0
+        )
+        + (usage.get("cache_read_input_tokens") or 0)
+        + (usage.get("cache_creation_input_tokens") or 0)
+    )
+    # Anthropic counts cache_read/creation against input (above).  For
+    # completion, prefer explicit fields; fall through to Gemini-style.
+    completion_axis = (
+        usage.get("completion_tokens")
+        or usage.get("output_tokens")
+        or (usage.get("candidatesTokenCount") or 0)
+        + (usage.get("thoughtsTokenCount") or 0)
+    )
+    return prompt_axis, completion_axis

--- a/src/agentopt/proxy/usage.py
+++ b/src/agentopt/proxy/usage.py
@@ -1,0 +1,320 @@
+"""Token-usage extraction from LLM API response bodies.
+
+Three input shapes are handled:
+
+* JSON object — OpenAI/Anthropic/Gemini single-response format.
+* JSON array — Gemini's ``streamGenerateContent`` non-SSE format
+  (returned without ``alt=sse``).
+* SSE stream — ``data: {...}`` frames from any provider's streaming API.
+
+All extraction returns ``(ParsedUsage | None, parse_failure_reason | None)``.
+The proxy uses the failure reason to attach a structured error to the
+``CallRecord`` so a successful call with unparseable usage isn't silently
+reported as zero tokens.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+
+# Sentinel model name for a 200 response whose usage we couldn't extract.
+PARSE_FAILED_MODEL = "<parse-failed>"
+
+
+# OpenAI-compatible chat/completions paths.  Used to surface the
+# ``stream_options.include_usage`` quirk specifically.
+_OPENAI_COMPAT_PATHS = (
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/chat/completions",
+)
+
+
+@dataclass(frozen=True)
+class ParsedUsage:
+    """Token usage extracted from an LLM response."""
+
+    model: Optional[str]
+    prompt_tokens: int
+    completion_tokens: int
+    response_body: dict  # representative chunk — kept for CallRecord debug
+
+
+# ---------------------------------------------------------------------------
+# Streaming detection
+# ---------------------------------------------------------------------------
+
+
+def is_streaming_request(request_body: dict, path_or_url: str) -> bool:
+    """Whether the request expects a streamed response.
+
+    Detects:
+    * OpenAI / Anthropic — ``"stream": true`` in the body.
+    * Gemini — ``:streamGenerateContent`` endpoint, with or without
+      ``?alt=sse`` (Gemini doesn't put a stream flag in the body).
+    """
+    if request_body.get("stream") is True:
+        return True
+    return "streamGenerateContent" in path_or_url or "alt=sse" in path_or_url
+
+
+def is_openai_compatible_url(url: str) -> bool:
+    path = urlparse(url).path or ""
+    return any(path.endswith(p) for p in _OPENAI_COMPAT_PATHS)
+
+
+def has_include_usage(request_body: dict) -> bool:
+    opts = request_body.get("stream_options")
+    return isinstance(opts, dict) and opts.get("include_usage") is True
+
+
+# ---------------------------------------------------------------------------
+# Per-provider usage shape — internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _gemini_completion_tokens(usage: dict) -> int:
+    """Sum visible output and reasoning tokens for Gemini thinking models.
+
+    Gemini reports ``candidatesTokenCount`` (visible) and
+    ``thoughtsTokenCount`` (reasoning) separately; both bill as output, so
+    callers want the sum.  Falls back to ``totalTokenCount - promptTokenCount``
+    if individual fields aren't broken out.
+    """
+    candidates = usage.get("candidatesTokenCount") or 0
+    thoughts = usage.get("thoughtsTokenCount") or 0
+    if candidates or thoughts:
+        return candidates + thoughts
+    total = usage.get("totalTokenCount")
+    prompt = usage.get("promptTokenCount") or 0
+    if isinstance(total, int) and total > prompt:
+        return total - prompt
+    return 0
+
+
+def _extract_usage_dict(usage: dict) -> Tuple[int, int]:
+    """``(prompt_tokens, completion_tokens)`` from any provider's usage dict."""
+    prompt = (
+        usage.get("prompt_tokens")
+        or usage.get("input_tokens")
+        or usage.get("promptTokenCount")
+        or 0
+    )
+    completion = (
+        usage.get("completion_tokens")
+        or usage.get("output_tokens")
+        or _gemini_completion_tokens(usage)
+    )
+    return prompt, completion
+
+
+def _parse_chunk(chunk: dict) -> Optional[ParsedUsage]:
+    """Pull usage from a single response object (any provider)."""
+    model = chunk.get("model") or chunk.get("modelVersion")
+    usage = chunk.get("usage") or chunk.get("usageMetadata")
+    msg = chunk.get("message")
+    if not usage and isinstance(msg, dict):
+        usage = msg.get("usage")
+        model = model or msg.get("model")
+    if not model or not usage:
+        return None
+    prompt, completion = _extract_usage_dict(usage)
+    return ParsedUsage(
+        model=model,
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        response_body=chunk,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public extractors
+# ---------------------------------------------------------------------------
+
+
+def extract_usage(body_bytes: bytes,) -> Tuple[Optional[ParsedUsage], Optional[str]]:
+    """Parse usage from a non-streaming response body.
+
+    Returns ``(usage, parse_failure_reason)``: exactly one is non-None.
+    """
+    if not body_bytes:
+        return None, "response body was empty"
+
+    try:
+        parsed = json.loads(body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return (
+            None,
+            (
+                f"response body is not valid JSON ({type(exc).__name__}); "
+                f"first 200 bytes: {body_bytes[:200]!r}"
+            ),
+        )
+
+    if isinstance(parsed, dict):
+        usage = _parse_chunk(parsed)
+        if usage is None:
+            return (
+                None,
+                (
+                    "response body is a JSON object but has no recognized "
+                    "usage/model fields (expected one of: usage, usageMetadata, "
+                    "input_tokens/output_tokens, prompt_tokens/completion_tokens, "
+                    "promptTokenCount/candidatesTokenCount). "
+                    f"keys present: {sorted(parsed.keys())[:10]}"
+                ),
+            )
+        return usage, None
+
+    if isinstance(parsed, list):
+        # Gemini's streamGenerateContent without alt=sse returns a JSON
+        # array of partial chunks; usage is on the final chunk(s).
+        best_model: Optional[str] = None
+        best_prompt = 0
+        best_completion = 0
+        any_extracted = False
+        for chunk in parsed:
+            if not isinstance(chunk, dict):
+                continue
+            u = _parse_chunk(chunk)
+            if u is None:
+                continue
+            any_extracted = True
+            best_model = best_model or u.model
+            if u.prompt_tokens > best_prompt:
+                best_prompt = u.prompt_tokens
+            if u.completion_tokens > best_completion:
+                best_completion = u.completion_tokens
+        last_obj = parsed[-1] if parsed and isinstance(parsed[-1], dict) else {}
+        if not any_extracted:
+            return (
+                None,
+                (
+                    f"response body is a JSON array of {len(parsed)} items but "
+                    "none carried recognized usage/model fields"
+                ),
+            )
+        return (
+            ParsedUsage(
+                model=best_model,
+                prompt_tokens=best_prompt,
+                completion_tokens=best_completion,
+                response_body=last_obj,
+            ),
+            None,
+        )
+
+    return (
+        None,
+        (
+            f"response body is JSON but neither object nor array "
+            f"(got {type(parsed).__name__})"
+        ),
+    )
+
+
+def extract_usage_streaming(
+    raw_sse: bytes, request_body: dict, request_url: str,
+) -> Tuple[Optional[ParsedUsage], Optional[str]]:
+    """Parse token usage from accumulated SSE bytes.
+
+    Anthropic splits usage across events (``message_start`` carries
+    input, ``message_delta`` carries output), so we scan all frames and
+    take the max of each axis.
+
+    Returns ``(usage, parse_failure_reason)``: exactly one is non-None.
+    """
+    text = raw_sse.decode("utf-8", errors="replace")
+    prompt_tokens = 0
+    completion_tokens = 0
+    model: Optional[str] = request_body.get("model")
+    sse_lines_seen = 0
+    found_usage = False
+
+    for line in text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        sse_lines_seen += 1
+        payload = line[len("data: ") :]
+        if payload.strip() == "[DONE]":
+            continue
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(chunk, dict):
+            continue
+
+        usage = chunk.get("usage") or chunk.get("usageMetadata")
+        msg = chunk.get("message")
+        if isinstance(msg, dict) and msg.get("usage"):
+            usage = usage or msg["usage"]
+        if not usage:
+            continue
+
+        # Anthropic counts cache_read/creation against input.
+        prompt_axis = (
+            (
+                usage.get("prompt_tokens")
+                or usage.get("input_tokens")
+                or usage.get("promptTokenCount")
+                or 0
+            )
+            + (usage.get("cache_read_input_tokens") or 0)
+            + (usage.get("cache_creation_input_tokens") or 0)
+        )
+        completion_axis = (
+            usage.get("completion_tokens")
+            or usage.get("output_tokens")
+            or _gemini_completion_tokens(usage)
+        )
+        if prompt_axis > prompt_tokens:
+            prompt_tokens = prompt_axis
+        if completion_axis > completion_tokens:
+            completion_tokens = completion_axis
+        model = model or chunk.get("model") or chunk.get("modelVersion")
+        if prompt_axis or completion_axis:
+            found_usage = True
+
+    if found_usage:
+        return (
+            ParsedUsage(
+                model=model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                response_body={},
+            ),
+            None,
+        )
+
+    # Diagnose.
+    if (
+        is_openai_compatible_url(request_url)
+        and request_body.get("stream") is True
+        and not has_include_usage(request_body)
+    ):
+        reason = (
+            "OpenAI-compatible streams omit usage by default — set "
+            '`stream_options={"include_usage": True}` on the request '
+            "to enable token tracking. (Anthropic streams are unaffected.)"
+        )
+    elif sse_lines_seen == 0:
+        reason = (
+            f"streaming response had no `data: ...` SSE frames "
+            f"(body length={len(raw_sse)} bytes, "
+            f"first 200 bytes={raw_sse[:200]!r}). "
+            "If this is a non-SSE chunked stream (e.g. Gemini's "
+            "`streamGenerateContent` without `alt=sse`), the non-streaming "
+            "code path handles JSON arrays; otherwise this provider's "
+            "streaming format may need explicit support in the proxy parser."
+        )
+    else:
+        reason = (
+            f"streaming response had {sse_lines_seen} SSE frames "
+            "but none carried recognized usage/model fields"
+        )
+    return None, reason

--- a/tests/test_call_recording.py
+++ b/tests/test_call_recording.py
@@ -41,7 +41,9 @@ class ControllableUpstream:
             "id": "c1",
             "object": "chat.completion",
             "model": "gpt-4o-mini",
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "hi"}}
+            ],
             "usage": {"prompt_tokens": 3, "completion_tokens": 2},
         }
 

--- a/tests/test_interceptor_paths.py
+++ b/tests/test_interceptor_paths.py
@@ -10,12 +10,16 @@ def _post(url: str) -> httpx.Request:
 
 
 def test_gemini_cli_oauth_paths_are_treated_as_llm_calls():
-    assert _is_llm_request(_post("https://cloudcode-pa.googleapis.com/v1internal:generateContent"))
+    assert _is_llm_request(
+        _post("https://cloudcode-pa.googleapis.com/v1internal:generateContent")
+    )
     assert _is_llm_request(
         _post("https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent")
     )
 
 
 def test_non_post_requests_are_not_treated_as_llm_calls():
-    request = httpx.Request(method="GET", url="https://api.openai.com/v1/chat/completions")
+    request = httpx.Request(
+        method="GET", url="https://api.openai.com/v1/chat/completions"
+    )
     assert not _is_llm_request(request)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -12,8 +12,7 @@ def test_detect_provider_gemini_cli_oauth_path():
 
 def test_resolve_target_gemini_cli_oauth_path_without_header():
     target_base, upstream_path = resolve_target(
-        "/v1internal:streamGenerateContent",
-        headers={},
+        "/v1internal:streamGenerateContent", headers={},
     )
     assert target_base == "https://cloudcode-pa.googleapis.com"
     assert upstream_path == "/v1internal:streamGenerateContent"

--- a/tests/test_register_provider.py
+++ b/tests/test_register_provider.py
@@ -1,8 +1,10 @@
 """Tests for LLMTracker.register_provider covering Direct + CONNECT modes."""
 
+import httpx
 import pytest
 
 from agentopt.proxy import LLMTracker
+from agentopt.proxy.interceptor import _is_llm_request
 
 
 @pytest.fixture
@@ -75,3 +77,54 @@ def test_instance_isolation(tracker):
         assert not other._server._should_intercept("openrouter.ai")
     finally:
         other.stop()
+
+
+def test_register_provider_updates_interceptor_paths(tracker):
+    """register_provider must extend the httpx-patch path set too.
+
+    Without this, in-process calls to a custom provider's path would not
+    match ``_is_llm_request`` and the proxy would never see them — silent
+    loss of tracking.
+    """
+    custom_path = "/openrouter-custom/respond"
+    request = httpx.Request(
+        method="POST", url=f"https://openrouter.ai{custom_path}", json={"prompt": "hi"},
+    )
+    assert not _is_llm_request(request)  # not yet registered
+
+    tracker.register_provider(
+        name="openrouter",
+        base_url="https://openrouter.ai",
+        path_patterns=(custom_path,),
+    )
+    assert _is_llm_request(request)
+
+
+def test_register_provider_records_in_process_call(mock_upstream):
+    """End-to-end: a custom provider's call is rewritten and recorded."""
+    tracker = LLMTracker(cache=False, cache_dir=None)
+    tracker.start()
+    try:
+        # Custom path that none of the built-ins cover.
+        tracker.register_provider(
+            name="local",
+            base_url=mock_upstream.base_url,
+            path_patterns=("/custom/llm/v9/respond",),
+        )
+        with tracker.track(data_id="dp", combo_id="c"):
+            with httpx.Client(base_url=mock_upstream.base_url) as client:
+                resp = client.post(
+                    "/custom/llm/v9/respond",
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+                assert resp.status_code == 200
+
+        records = tracker.get_records()
+        assert len(records) == 1
+        assert records[0].request_url.endswith("/custom/llm/v9/respond")
+        assert records[0].status_code == 200
+    finally:
+        tracker.stop()


### PR DESCRIPTION
- Single source of truth. 
providers.py now exposes one Provider type and one ProviderRegistry class. register_provider updates direct-mode patterns and the CONNECT-mode intercept set together. The interceptor's _LLM_PATH_PATTERNS is now derived from DEFAULT_PROVIDERS, so adding a built-in provider no longer means editing two hand-maintained lists.

- Pure usage extraction. 
usage.py is a new module containing only pure functions: extract_usage(bytes) → (ParsedUsage, reason) and extract_usage_streaming(bytes, body, url). Each handles all three response shapes (JSON object / JSON array / SSE) and returns a structured failure reason on parse miss. The server's recorder shrunk from ~250 lines of intermixed parsing+building to ~70 lines.

- One request lifecycle. 
server.py now has a single _process_and_respond (cache → forward → record → respond) called by both modes. The duplication between the old async _handle_direct and sync _handle_connect_blocking is gone.

- Sync, threaded, no asyncio in the proxy. 
Listener thread per session, connection thread per accept. Forwarding via stdlib http.client. TLS termination via ssl.SSLContext.wrap_socket. This is what eliminated the async/sync split that was forcing the duplication.

- Smaller test-touchable surface kept stable.
_should_intercept, _providers membership, detect_provider, resolve_target, _is_llm_request, _session_port_var, ProviderConfig alias, DEFAULT_PROVIDERS, INTERCEPT_HOSTS — all preserved.

- One small public-API improvement. 
ProxyServer.get_session_port(session_id) replaces the private _session_listeners[...] lookup that tracker.get_session_env was reaching into.