### PR TITLE
fix issue for gemini: For the openai/anthropic provider that had been…

### DIFF
--- a/src/agentopt/proxy/cache.py
+++ b/src/agentopt/proxy/cache.py
@@ -32,15 +32,20 @@ _DEFAULT_FLUSH_INTERVAL = 10.0
 _DB_FILENAME = "cache.db"
 
 
-def _make_cache_key(request_body: dict) -> str:
+def _make_cache_key(request_body: dict, request_path: Optional[str] = None) -> str:
     """Deterministic hash of the request payload.
 
     Includes every field that affects the response (model, messages,
     temperature, etc.) but excludes ephemeral metadata like ``stream``.
+
+    ``request_path`` is folded into the hash so providers that key the
+    model in the URL (e.g. Gemini's ``/v1beta/models/{model}:generateContent``)
+    don't collide across models that produce byte-identical request bodies.
     """
     body = {k: v for k, v in request_body.items() if k not in ("stream",)}
     canonical = json.dumps(body, sort_keys=True, ensure_ascii=True)
-    return hashlib.sha256(canonical.encode()).hexdigest()
+    path_part = request_path or ""
+    return hashlib.sha256(f"{path_part}\n{canonical}".encode()).hexdigest()
 
 
 @dataclass

--- a/src/agentopt/proxy/interceptor.py
+++ b/src/agentopt/proxy/interceptor.py
@@ -145,7 +145,7 @@ def _record_after_response(
     # Cache successful 200s on the miss path only.
     if not cached and status == 200 and active.cache is not None and json_body:
         active.cache.put(
-            _make_cache_key(json_body),
+            _make_cache_key(json_body, str(request.url.path)),
             CacheEntry(
                 response_bytes=body_bytes,
                 response_headers=dict(response.headers),
@@ -186,7 +186,7 @@ def install_redirect() -> None:
         json_body = _decode_json_body(request.content)
         # Cache lookup
         if active.cache is not None and json_body:
-            entry = active.cache.get(_make_cache_key(json_body))
+            entry = active.cache.get(_make_cache_key(json_body, str(request.url.path)))
             if entry is not None:
                 resp = _make_cached_response(request, entry)
                 _record_after_response(
@@ -217,7 +217,7 @@ def install_redirect() -> None:
 
         json_body = _decode_json_body(request.content)
         if active.cache is not None and json_body:
-            entry = active.cache.get(_make_cache_key(json_body))
+            entry = active.cache.get(_make_cache_key(json_body, str(request.url.path)))
             if entry is not None:
                 resp = _make_cached_response(request, entry)
                 _record_after_response(

--- a/src/agentopt/proxy/mitm_addon.py
+++ b/src/agentopt/proxy/mitm_addon.py
@@ -99,7 +99,7 @@ class AgentoptAddon:
         if self._cache is None or flow.request.method != "POST" or not json_body:
             return
 
-        cache_key = _make_cache_key(json_body)
+        cache_key = _make_cache_key(json_body, flow.request.path)
         entry = self._cache.get(cache_key)
         if entry is None:
             return
@@ -155,7 +155,7 @@ class AgentoptAddon:
         # Cache successful 200s on the miss path.
         if not cached and status == 200 and self._cache is not None and json_body:
             self._cache.put(
-                _make_cache_key(json_body),
+                _make_cache_key(json_body, flow.request.path),
                 CacheEntry(
                     response_bytes=body_bytes,
                     response_headers=dict(flow.response.headers),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -84,6 +84,18 @@ class TestMakeCacheKey:
         body2 = {"messages": [], "temperature": 0.5, "model": "gpt-4o"}
         assert _make_cache_key(body1) == _make_cache_key(body2)
 
+    def test_different_path_different_key(self):
+        # Gemini-style: identical body but model encoded in the URL path.
+        body = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+        path_pro = "/v1beta/models/gemini-2.5-pro:streamGenerateContent"
+        path_flash = "/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+        assert _make_cache_key(body, path_pro) != _make_cache_key(body, path_flash)
+
+    def test_same_path_same_key(self):
+        body = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+        path = "/v1/chat/completions"
+        assert _make_cache_key(body, path) == _make_cache_key(body, path)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: cache through proxy server


### PR DESCRIPTION
## Summary
- Fix cache-key collision for providers that encode the model in the URL path (Gemini's `/v1beta/models/{model}:generateContent`). Previously `_make_cache_key` hashed only the JSON request body, so a flash and a pro call with identical bodies produced the same key — the second model served the first's cached response, and both combos reported identical (wrong) costs.
- `_make_cache_key` now folds the request path into the hash; mitmproxy and in-process httpx call sites pass it.
- Added a regression test using the exact Gemini path shape that triggered this.

Why it wasn't caught: OpenAI / Anthropic put the model in the body (no collision), and the existing Gemini smoke test only covers the OAuth endpoint (model also in body). The API-key path was never exercised.

Note: this invalidates existing `.agentopt_cache` entries.

## Test plan
- [x] `pytest tests/test_cache.py tests/test_disk_cache.py tests/test_interceptor_paths.py tests/test_gemini_cli_smoke.py tests/test_call_recording.py` — 56 passed
- [x] Re-run `examples/gemini_cli_example.py` with a Gemini API key after deleting `.agentopt_cache`; flash and pro should now show distinct token dicts and diverging prices
