### PR TITLE
support for openharness

### DIFF
--- a/examples/gemini_cli_example.py
+++ b/examples/gemini_cli_example.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
         agent=GeminiCLIAgent,
         models={
             "agent": [
-                "gemini-2.5-flash",
                 "gemini-2.5-pro",
+                "gemini-2.5-flash",
                 # Add or swap models you have access to.
             ],
         },

--- a/examples/gemini_cli_example.py
+++ b/examples/gemini_cli_example.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
         agent=GeminiCLIAgent,
         models={
             "agent": [
-                "gemini-2.5-pro",
                 "gemini-2.5-flash",
+                "gemini-2.5-pro",
                 # Add or swap models you have access to.
             ],
         },

--- a/examples/openharness_example.py
+++ b/examples/openharness_example.py
@@ -1,0 +1,183 @@
+"""
+Example: OpenHarness (``oh`` CLI) with agentopt.
+
+Find the best LLM model for your OpenHarness tasks. The agent wraps the
+``oh`` CLI as a subprocess; agentopt sets ``HTTPS_PROXY`` and a CA bundle
+so all LLM traffic from the subprocess routes through the tracking proxy,
+and records model/tokens/latency per call.
+
+The ``oh`` CLI (https://github.com/HKUDS/OpenHarness) is a Python tool
+that uses the official Anthropic/OpenAI SDKs under the hood, which means
+it honours ``HTTPS_PROXY`` / ``SSL_CERT_FILE`` env vars out of the box —
+no config-file patching needed. ``--api-key`` and ``--base-url`` flags
+let us bypass interactive ``oh setup`` entirely.
+
+Prerequisites:
+    1. pip install agentopt-py
+    2. Install OpenHarness:  pip install openharness-ai   (or `uv tool install openharness-ai`)
+    3. Set ANTHROPIC_API_KEY and/or OPENAI_API_KEY in your environment.
+
+Usage:
+    python examples/openharness_example.py
+"""
+
+import os
+import subprocess
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import agentopt
+from agentopt import ModelSelector
+
+OH_TIMEOUT = 120  # seconds per call
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Define the agent class.
+# __init__(models) receives a model config dict; run(input_data) shells out
+# to `oh -p` and returns the stdout text.
+#
+# Model strings use a "<format>/<model_id>" convention so one agent can
+# select across Anthropic and OpenAI-compatible providers:
+#   "anthropic/claude-haiku-4-5"  ->  --api-format anthropic
+#   "openai/gpt-4o-mini"          ->  --api-format openai
+# ---------------------------------------------------------------------------
+
+
+PROVIDER_DEFAULTS = {
+    "anthropic": {
+        "base_url": "https://api.anthropic.com",
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
+    "openai": {
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+    },
+}
+
+
+class OpenHarnessAgent:
+    """Wraps the ``oh`` CLI as a subprocess for agentopt model selection."""
+
+    def __init__(self, models):
+        spec = models["agent"]
+        if "/" not in spec:
+            raise ValueError(
+                f"model must be '<format>/<model_id>' (e.g. 'anthropic/claude-haiku-4-5'); got {spec!r}"
+            )
+        self.api_format, self.model = spec.split("/", 1)
+        if self.api_format not in PROVIDER_DEFAULTS:
+            raise ValueError(
+                f"unsupported api_format {self.api_format!r}; expected one of {list(PROVIDER_DEFAULTS)}"
+            )
+        defaults = PROVIDER_DEFAULTS[self.api_format]
+        api_key = os.environ.get(defaults["api_key_env"])
+        if not api_key:
+            raise RuntimeError(f"{defaults['api_key_env']} not set in environment")
+        self.api_key = api_key
+        self.base_url = defaults["base_url"]
+
+    def run(self, input_data):
+        prompt = input_data if isinstance(input_data, str) else input_data["prompt"]
+
+        cmd = [
+            "oh",
+            "-p",
+            prompt,
+            "--api-format",
+            self.api_format,
+            "--base-url",
+            self.base_url,
+            "--api-key",
+            self.api_key,
+            "--model",
+            self.model,
+            "--bare",  # skip hooks/plugins/MCP/auto-discovery
+            "--dangerously-skip-permissions",  # non-interactive, no permission prompts
+            "--max-turns",
+            "1",  # single turn for eval
+            "--output-format",
+            "text",
+        ]
+
+        # Route subprocess LLM calls through agentopt's tracking proxy.
+        # `oh` uses the official anthropic/openai SDKs, which read these env
+        # vars via their default httpx clients.
+        proxy = agentopt.get_current_session_proxy()
+        env = {
+            **os.environ,
+            **(proxy.env_dict() if proxy else {}),
+        }
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=OH_TIMEOUT, env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return f"FAILED: oh timeout after {OH_TIMEOUT}s"
+        except FileNotFoundError:
+            return "FAILED: oh CLI not found — install with: pip install openharness-ai"
+
+        if result.returncode != 0:
+            return f"FAILED: oh exit {result.returncode}: {result.stderr.strip()[:300]}"
+        return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Evaluation dataset — (prompt, expected_answer) pairs.
+# ---------------------------------------------------------------------------
+
+dataset = [
+    ("What is the capital of France? Answer in one word.", "Paris"),
+    ("What is 2 + 2? Answer with just the number.", "4"),
+    ("What color is the sky on a clear day? Answer in one word.", "blue"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Evaluation function — substring match with debug surfacing.
+# ---------------------------------------------------------------------------
+
+
+def eval_fn(expected, actual):
+    actual_str = str(actual)
+    if "FAILED" in actual_str:
+        print(f"  [debug] sample FAILED: {actual_str[:300]}")
+        return 0.0
+    matched = expected.lower() in actual_str.lower()
+    if not matched:
+        print(f"  [debug] no match — expected={expected!r}, got={actual_str[:200]!r}")
+    return 1.0 if matched else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Run model selection.
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    try:
+        subprocess.run(["oh", "--version"], capture_output=True, timeout=10)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        print(
+            "Error: `oh` CLI not found. Install with `pip install openharness-ai` "
+            "or `uv tool install openharness-ai`."
+        )
+        sys.exit(1)
+
+    selector = ModelSelector(
+        agent=OpenHarnessAgent,
+        models={"agent": ["openai/gpt-4o-mini", "openai/gpt-5.1", "openai/gpt-4.1",],},
+        eval_fn=eval_fn,
+        dataset=dataset,
+        method="brute_force",
+    )
+
+    results = selector.select_best(parallel=False)
+    results.print_summary()
+
+    best = results.get_best_combo()
+    if best:
+        print(f"\nBest model: {best}")

--- a/src/agentopt/proxy/mitm_addon.py
+++ b/src/agentopt/proxy/mitm_addon.py
@@ -33,7 +33,7 @@ from .cache import CacheEntry, ResponseCache, _make_cache_key
 from .providers import ProviderRegistry
 from .recording import Recorder
 from .session import SessionInfo
-from .usage import is_streaming_request
+from .usage import has_include_usage, is_openai_compatible_url, is_streaming_request
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +94,16 @@ class AgentoptAddon:
     def request(self, flow: http.HTTPFlow) -> None:
         json_body = _decode_json_body(flow.request.content)
         flow.metadata[_T0_KEY] = time.monotonic()
+
+        # OpenAI-compatible streaming: force `stream_options.include_usage`
+        # so the SSE response carries a usage frame. Some subprocess agents
+        # (OpenHarness's `oh` does this whenever any tool is attached, as a
+        # Kimi/Moonshot compat hack) strip it from the request, which
+        # otherwise leaves the proxy unable to count tokens.
+        if _ensure_openai_include_usage(json_body, flow.request.pretty_url):
+            flow.request.content = json.dumps(json_body, separators=(",", ":")).encode(
+                "utf-8"
+            )
 
         # Only POSTs with JSON bodies are LLM calls worth caching.
         if self._cache is None or flow.request.method != "POST" or not json_body:
@@ -223,3 +233,23 @@ def _safe_response_headers(headers: Dict[str, str]) -> Dict[str, str]:
     return {
         k: v for k, v in headers.items() if k.lower() not in _RESPONSE_HEADERS_STRIP
     }
+
+
+def _ensure_openai_include_usage(json_body: Dict[str, Any], request_url: str) -> bool:
+    """Inject ``stream_options.include_usage=True`` for OpenAI-compatible streams.
+
+    Returns True if the body was mutated.  No-op for non-streaming
+    requests, non-OpenAI-compatible URLs, or bodies that already opted in.
+    """
+    if not is_openai_compatible_url(request_url):
+        return False
+    if json_body.get("stream") is not True:
+        return False
+    if has_include_usage(json_body):
+        return False
+    opts = json_body.get("stream_options")
+    if isinstance(opts, dict):
+        opts["include_usage"] = True
+    else:
+        json_body["stream_options"] = {"include_usage": True}
+    return True


### PR DESCRIPTION
## Summary

- Add `OpenHarnessAgent` wrapper + example for the [`oh` CLI](https://github.com/HKUDS/OpenHarness) — wraps `oh -p` as a subprocess and routes traffic through agentopt via `HTTPS_PROXY` + `SSL_CERT_FILE`. Uses `--api-format` / `--base-url` / `--api-key` so it bypasses interactive `oh setup`. Model spec format `<format>/<model_id>` selects across both Anthropic and OpenAI-compatible providers in one agent class.
- Fix token tracking for OpenAI-compatible streaming requests that omit `stream_options.include_usage`. `oh` strips `stream_options` whenever any tool is attached (a Kimi/Moonshot compat hack), and `oh` always registers ~30 built-in tools. Without `include_usage`, OpenAI's SSE never emits a usage frame, so the proxy can't count tokens. The addon now injects `include_usage=True` on the wire for any OpenAI-compatible streaming POST that doesn't already opt in — benefits any subprocess agent speaking the OpenAI chat-completions protocol, not just `oh`.

## Why a proxy-side injection rather than an `oh`-side fix

`oh`'s strip-when-tools-present logic only matters for providers like Moonshot. For real OpenAI / DeepSeek / Groq / etc. it just blocks observability. Patching it upstream needs a PR + release in OpenHarness; rewriting the request in our addon is ~25 lines, gated to OpenAI-compatible paths, and unblocks every subprocess CLI today.

## Files

- `examples/openharness_example.py` (new) — `OpenHarnessAgent` + dataset
- `src/agentopt/proxy/mitm_addon.py` — import `has_include_usage` / `is_openai_compatible_url` (existing helpers in `usage.py`); inject in `request` hook before cache lookup; new `_ensure_openai_include_usage()` helper

## Test plan

- [x] Unit cases for the helper: inject on OpenAI stream, no-op when already opt-in, merge into existing `stream_options` dict, skip Anthropic, fire on third-party OpenAI-compat hosts (DeepSeek/Groq pattern)
- [x] End-to-end with real `oh` subprocess against a local SSE stub that mimics OpenAI's behavior (emits usage frame only when `include_usage` is on the request). With the fix: 1 record captured, `prompt_tokens=13 completion_tokens=4`. Recorded `request_body.stream_options` shows the injected `{"include_usage": True}`.
- [x] Existing suite: `uv run pytest tests/ -x -q` → **85/85 pass**
- [x] Live `examples/openharness_example.py` run with a valid `OPENAI_API_KEY` (the `.env` key I tested with returns 401 from OpenAI; the wrapper itself works — confirmed via stub)
