### PR TITLE
enable daemon

### DIFF
--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -108,6 +108,82 @@ This is a design choice, not a forced constraint. Alternatives we rejected:
 
 Per-session masters cost ~100-300ms startup and ~30MB RSS each. Acceptable for research workloads where session count is low and parallel safety matters more than absolute throughput.
 
+## Local vs daemon mode: where the proxy lives
+
+Everything above describes the *mechanism* of interception. Orthogonal to that mechanism is the question of *where* the proxy runs — in the same Python process as your selector code, or in a long-lived daemon.
+
+`LLMTracker` picks the mode automatically from a single environment variable:
+
+```bash
+# Default — in-process: spins per-session mitmproxy masters in this process.
+python my_script.py
+
+# Daemon mode — talk to a long-lived gateway.
+AGENTOPT_GATEWAY_URL=http://127.0.0.1:9000 python my_script.py
+```
+
+The user-facing API is byte-identical between modes. `ModelSelector(...).select_best()`, `tracker.track()`, `tracker.get_records()` — none of it changes. Switching modes is a deployment decision, not an API decision.
+
+### What's identical between modes
+
+Same proxy mechanism end-to-end. Per-session mitmproxy masters, the same `AgentoptAddon`, same CA, same path-pattern detection, same `CallRecord` schema. The only thing that varies is *which process* owns the master.
+
+### What differs
+
+| | Local mode | Daemon mode |
+|---|---|---|
+| Where the master runs | The user's Python process | The `agentopt serve` daemon |
+| Where the cache + records live | In-process | On the daemon |
+| Where the in-process httpx patch sends traffic | Directly to the upstream LLM API | Through the daemon's per-session proxy port |
+| Multi-process / multi-language clients | Subprocess agents only | First-class: any client that respects `HTTPS_PROXY` |
+| State outlives a single experiment | No (process-bound) | Yes (daemon-bound) |
+| Setup | None | Run `agentopt serve` separately |
+
+### The `agentopt serve` daemon
+
+A small `aiohttp.web` app that owns one `LocalBackend` and exposes its surface over HTTP. Localhost-only in v1 (no auth).
+
+```bash
+agentopt serve --port 9000 --cache-dir .agentopt_cache
+```
+
+Control plane:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET`    | `/health`                          | liveness probe |
+| `POST`   | `/sessions`                        | open a session — returns `{session_id, proxy_port, ca_pem_b64}` |
+| `DELETE` | `/sessions/{session_id}`           | close a session |
+| `GET`    | `/records?data_id=&combo_id=…`     | filtered `CallRecord` list |
+| `GET`    | `/usage?…`                         | aggregated token usage |
+| `GET`    | `/cached_latency?…`                | total cached-response latency |
+| `POST`   | `/cache/flush`                     | force-flush dirty cache rows |
+| `POST`   | `/cache/clear`                     | drop all cached responses |
+| `POST`   | `/providers`                       | register a custom LLM provider |
+| `GET`    | `/ca`                              | mitmproxy CA cert (also returned in `POST /sessions`) |
+
+The daemon refuses to bind a non-loopback host without `--allow-remote`, which is reserved for a future revision that ships authentication. Until then, refusing fast is safer than accidentally exposing an unauthenticated proxy on the network.
+
+### How the in-process httpx patch routes in daemon mode
+
+In local mode the patched `httpx.Client.send` does the work itself (cache lookup, forward to upstream, record). In daemon mode it would be duplicate machinery — the daemon's `AgentoptAddon` already does all of that. So the patched `send` instead forwards the original request through an `httpx.Client(proxy=daemon_session_url, verify=daemon_ca_bundle)`, and the daemon records + caches.
+
+The seam is a small `CallHandler` ABC inside `interceptor.py`. Two implementations:
+
+- **`LocalHandler`** — today's behaviour (cache, forward to real upstream, record).
+- **`RemoteHandler`** — forwards through the daemon's per-session proxy port; the daemon does cache + record.
+
+Both are bound to the `ActiveSession` ContextVar at `track()` entry. The patched `send` is a one-line dispatcher: `return active.handler.handle_sync(...)`. Nothing about the activation, path-pattern filter, or `_active_session_var` plumbing changes between modes.
+
+### Why daemon mode at all
+
+Two motivations:
+
+1. **Multi-language / multi-process clients.** Subprocess agents work today via `HTTPS_PROXY`, but each Python process spins its own proxy. With a daemon, one gateway serves any number of clients in any language — they all just point `HTTPS_PROXY` at the same per-session port returned by `POST /sessions`.
+2. **State that outlives a process.** Cache survives across runs. Records can be queried later. A foundation for future features (concurrency caps, request coalescing, cross-call observability) that need a global view a single-process library can't supply.
+
+Routing is intentionally library-only for now — user-supplied Python `Router` callables don't translate cleanly across the wire and the cost of supporting them at v1 wasn't worth it. The daemon focuses on tracking, caching, and shared infrastructure.
+
 ## The complete flow
 
 Here's everything that happens end-to-end when you run an evaluation:
@@ -122,7 +198,9 @@ Here's everything that happens end-to-end when you run an evaluation:
 
 **Session teardown**: `track()` scope exits → ContextVar is reset, the SessionMaster is shut down (drains in-flight requests, joins the thread), and the session is archived.
 
-**Shutdown**: `tracker.stop()` restores the original `httpx.Client.send`, stops any remaining masters, and flushes the cache.
+**Shutdown**: `tracker.stop()` restores the original `httpx.Client.send`, stops any remaining masters, and flushes the cache. Record queries remain valid after `stop()`; `tracker.close()` does the final teardown (release the remote backend's long-lived HTTP client). `LLMTracker` is a context manager — `with LLMTracker() as t:` calls `close()` on exit.
+
+In daemon mode the same calls dispatch over HTTP: `start()` health-checks the daemon, `track()` POSTs `/sessions`, `stop()` closes any lingering sessions, `close()` releases the control-plane client.
 
 ## Session lifecycle
 
@@ -186,26 +264,34 @@ track(combo_id="gpt4o+gpt4o-mini") → SessionMaster on port 59205
 
 ### `agentopt.proxy`
 
-The interception machinery, split between the in-process httpx wrapper and the per-session mitmproxy addon.  Both call into the same recording / cache / token-extraction code, so a record is a record regardless of how the call arrived.
+The interception machinery, split between the in-process httpx wrapper, the per-session mitmproxy addon, and (optionally) a long-lived `agentopt serve` daemon.  All paths call into the same recording / cache / token-extraction code, so a record is a record regardless of how the call arrived.
 
-- **`interceptor.py`** — the httpx monkey-patch.  On an LLM request inside an active session: cache lookup, then either short-circuit on hit or call the real upstream and record.  No localhost listener.  Path-pattern set is a frozenset rebuilt-on-write so `register_provider` can extend it without racing the wrapper hot path.
+- **`tracker.py`** — `LLMTracker`.  Public surface.  Thin delegator that picks a backend in `__init__` based on `AGENTOPT_GATEWAY_URL`.  Context-manager-friendly: `with LLMTracker() as t:`.
+- **`_backend.py`** — `_Backend` ABC and the shared CA-bundle helpers (`_MITMPROXY_CA_CERT`, `_ensure_ca_bundle`).  Both backends import from here.
+- **`_local_backend.py`** — `LocalBackend`.  Per-session mitmproxy in this process; holds the shared `SessionManager`, `ResponseCache`, `ProviderRegistry`, `Recorder`; manages `SessionMaster` lifecycles per `track()`.
+- **`_remote_backend.py`** — `RemoteBackend` and `RemoteHandler`.  Talks to the daemon's HTTP control plane; the in-process httpx patch's slow path forwards through the daemon's per-session port instead of recording locally.
+- **`daemon.py`** — `aiohttp.web` app wrapping a singleton `LocalBackend`; CLI entrypoint registers the `agentopt serve` subparser.  Warms up mitmproxy's CA on startup so the first `/sessions` POST doesn't have to.
+- **`cli.py`** — top-level `agentopt` argparse dispatcher; subcommands register themselves via `set_defaults(func=...)`.
+- **`interceptor.py`** — the httpx monkey-patch.  On an LLM request inside an active session, the patched `send` is a one-line dispatcher to `active.handler.handle_{sync,async}`.  Two handlers: `LocalHandler` (today's cache+forward+record body) and `RemoteHandler` (forwards through the daemon).  Path-pattern set is a frozenset rebuilt-on-write so `register_provider` can extend it without racing the wrapper hot path.
 - **`mitm_addon.py`** — `AgentoptAddon` for mitmproxy.  Hooks: `tls_clienthello` decides intercept-vs-passthrough at the SNI level; `request` does cache lookup and short-circuit; `response` records and caches; `error` records transport failures.
 - **`mitm_runner.py`** — `SessionMaster`: hosts one `DumpMaster` per session in a background thread with its own asyncio loop.  Captures the bound port via the `running` addon hook.  Documents the embedded mitmproxy API surface we depend on so a major-version bump is traceable.
 - **`recording.py`** — `Recorder`.  The single function that turns (session, request body, response body, latency, status) into a `CallRecord` and dispatches to `SessionManager`.  Owns the warn-once-per-host set for token-extraction failures.  Both the httpx wrapper and the addon use the same instance.
-- **`tracker.py`** — `LLMTracker`.  Holds the shared `SessionManager`, `ResponseCache`, `ProviderRegistry`, `Recorder`; manages `SessionMaster` lifecycles per `track()`; merges mitmproxy's CA with `certifi`'s system bundle into a file subprocesses can use.
-- **`providers.py`** — `Provider` dataclass and `ProviderRegistry`.  Per-`LLMTracker` catalog of LLM hostnames and path patterns.
+- **`providers.py`** — `Provider` dataclass and `ProviderRegistry`.  Per-`LocalBackend` catalog of LLM hostnames and path patterns.
 - **`usage.py`** — pure token-extraction for OpenAI / Anthropic / Gemini response shapes (JSON object, JSON array, SSE).  Raises `UsageExtractionError` with a structured diagnostic on miss; never reports zero tokens silently.
 - **`cache.py`** — `ResponseCache`.  In-memory dict, optionally persisted to SQLite via a daemon flush thread.  Keyed by a hash of the request body (excluding `stream`).
 - **`session.py`** — `SessionManager`.  Active and archived sessions; `add_record` checks both so a slow upstream that finishes after `end_session` doesn't drop its record.
 
 ### `agentopt.proxy.LLMTracker` (the public surface)
 
-- `tracker.start()` / `tracker.stop()` lifecycle
-- `tracker.track(data_id, combo_id, agent_id)` context manager — creates a session, eagerly spins up a SessionMaster, sets the ContextVar
-- `tracker.get_session_env(session)` — env-var dict for subprocess agents (`HTTPS_PROXY` + the merged CA bundle path)
-- `tracker.register_provider(name, base_url, path_patterns)` — extends both the shared `ProviderRegistry` (subprocess intercept hosts) and the httpx wrapper's path-pattern set (in-process detection)
-- `tracker.get_records(...)`, `tracker.get_usage(...)`, `tracker.get_cached_latency(...)` — query recorded calls
-- `tracker.flush_cache()`, `tracker.clear_cache()`, `tracker.clear()`
+Identical between local and daemon modes. Reads `AGENTOPT_GATEWAY_URL` in `__init__` to pick the backend.
+
+- `tracker.start()` / `tracker.stop()` / `tracker.close()` lifecycle. Record queries remain valid after `stop()`; `close()` is the final-teardown hook that releases the remote backend's long-lived HTTP client.
+- `with LLMTracker() as tracker:` — context-manager sugar that calls `close()` on exit.
+- `tracker.track(data_id, combo_id, agent_id)` context manager — creates a session, eagerly spins up a SessionMaster (local) or POSTs `/sessions` (remote), sets the ContextVar.
+- `tracker.get_session_env(session)` — env-var dict for subprocess agents (`HTTPS_PROXY` + the merged CA bundle path). The proxy URL points at the local SessionMaster or the daemon's per-session port, transparently.
+- `tracker.register_provider(name, base_url, path_patterns)` — extends both the shared `ProviderRegistry` (subprocess intercept hosts) and the httpx wrapper's path-pattern set (in-process detection). In remote mode, also POSTs `/providers` to keep the daemon in sync.
+- `tracker.get_records(...)`, `tracker.get_usage(...)`, `tracker.get_cached_latency(...)` — query recorded calls.
+- `tracker.flush_cache()`, `tracker.clear_cache()`, `tracker.clear()`.
 
 ### The httpx wrapper (no business logic — delegates to `Recorder` + `ResponseCache`)
 
@@ -257,6 +343,7 @@ Every layer of complexity is forced by a real constraint, not a design choice:
 4. But the agent rejects fake certificates → need a custom CA in the trust store
 5. But we need to know which calls belong to which combo → use a separate port per session
 6. But `os.environ` isn't safe for parallel subprocesses → pass env explicitly to each subprocess instead of mutating globals
+7. But state dies with the Python process and other languages can't share it → run the same proxy code as a long-lived `agentopt serve` daemon; clients pick local vs daemon via the `AGENTOPT_GATEWAY_URL` env var, with no API change
 
 ## Scoping constraints
 

--- a/examples/daemon_example.py
+++ b/examples/daemon_example.py
@@ -1,0 +1,100 @@
+"""
+Example: same selection script, local proxy vs. ``agentopt serve`` daemon.
+
+The user-facing API does not change between local and daemon modes; the
+``AGENTOPT_GATEWAY_URL`` env var is the entire switch.
+
+Local mode (default — spins up an in-process mitmproxy per session)::
+
+    python examples/daemon_example.py
+
+Daemon mode (one long-lived gateway shared by every script and language)::
+
+    # Terminal 1 — start the daemon (Ctrl-C to stop).
+    agentopt serve
+
+    # Terminal 2 — same script, just point at the daemon.
+    AGENTOPT_GATEWAY_URL=http://127.0.0.1:9000 \\
+        python examples/daemon_example.py
+
+The selector script (below) is byte-identical between the two runs.
+
+Prerequisites:
+    1. ``pip install agentopt-py openai``
+    2. ``export OPENAI_API_KEY=...``
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from openai import OpenAI
+
+from agentopt import ModelSelector
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Define your agent class.
+# ---------------------------------------------------------------------------
+
+
+class MyAgent:
+    """One-shot OpenAI chat completion."""
+
+    def __init__(self, models):
+        self.client = OpenAI()
+        self.model = models["agent"]
+
+    def run(self, input_data: str) -> str:
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": "Answer in one word."},
+                {"role": "user", "content": input_data},
+            ],
+        )
+        return resp.choices[0].message.content or ""
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Dataset + scoring.
+# ---------------------------------------------------------------------------
+
+
+dataset = [
+    ("What is the capital of France?", "Paris"),
+    ("What is 2 + 2?", "4"),
+    ("What color is the sky on a clear day?", "blue"),
+]
+
+
+def eval_fn(expected: str, actual: str) -> float:
+    return 1.0 if expected.lower() in str(actual).lower() else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Run.  Nothing here knows about local vs. daemon mode.
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    gateway = os.environ.get("AGENTOPT_GATEWAY_URL")
+    print(f"Mode: {'remote → ' + gateway if gateway else 'local (in-process proxy)'}")
+
+    selector = ModelSelector(
+        agent=MyAgent,
+        models={"agent": ["gpt-4o-mini", "gpt-4.1-nano"]},
+        eval_fn=eval_fn,
+        dataset=dataset,
+        method="brute_force",
+    )
+    results = selector.select_best(parallel=False)
+    results.print_summary()
+
+    best = results.get_best_combo()
+    if best:
+        print(f"\nBest model: {best}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ plot = ["matplotlib>=3.5"]
 dev = ["pytest>=8.0"]
 docs = ["mkdocs-material", "mkdocstrings[python]"]
 
+[project.scripts]
+agentopt = "agentopt.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/AgentOptimizer/agentopt"
 Documentation = "https://agentoptimizer.github.io/agentopt"

--- a/src/agentopt/cli.py
+++ b/src/agentopt/cli.py
@@ -1,8 +1,14 @@
-"""``agentopt`` CLI — currently dispatches a single subcommand: ``serve``.
+"""``agentopt`` CLI — top-level argparse dispatcher.
 
-Wired to ``pyproject.toml``'s ``[project.scripts]`` table as
-``agentopt = "agentopt.cli:main"``.  Run ``agentopt serve --help`` for
-daemon options.
+Wired to ``pyproject.toml``'s ``[project.scripts]`` as
+``agentopt = "agentopt.cli:main"``.
+
+Each subcommand registers itself by adding a subparser and calling
+``set_defaults(func=<handler>)``; :func:`main` dispatches via
+``args.func(args)``.  This pattern keeps ``--help`` ergonomics
+predictable at every level (``agentopt --help``,
+``agentopt serve --help``) without the ``parse_known_args`` /
+``add_help=False`` workarounds those break.
 """
 
 from __future__ import annotations
@@ -17,22 +23,18 @@ def main(argv: Optional[List[str]] = None) -> None:
         prog="agentopt",
         description="agentopt — LLM model selection + per-call tracking",
     )
-    subs = parser.add_subparsers(dest="cmd", required=True)
-    subs.add_parser(
-        "serve",
-        help="Run the long-lived gateway daemon. See `agentopt serve --help`.",
-        add_help=False,
+    subparsers = parser.add_subparsers(
+        dest="cmd", required=True, metavar="COMMAND",
     )
-    # Parse only the first positional so subcommands can own their own flags.
-    args, rest = parser.parse_known_args(argv)
 
-    if args.cmd == "serve":
-        from .proxy.daemon import cli as serve_cli
+    # Subcommands register themselves here.  Each must call
+    # `set_defaults(func=<handler>)` so dispatch below stays generic.
+    from .proxy.daemon import register_serve_subparser
 
-        serve_cli(rest)
-        return
+    register_serve_subparser(subparsers)
 
-    parser.error(f"unknown subcommand: {args.cmd!r}")
+    args = parser.parse_args(argv)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/agentopt/cli.py
+++ b/src/agentopt/cli.py
@@ -1,0 +1,39 @@
+"""``agentopt`` CLI — currently dispatches a single subcommand: ``serve``.
+
+Wired to ``pyproject.toml``'s ``[project.scripts]`` table as
+``agentopt = "agentopt.cli:main"``.  Run ``agentopt serve --help`` for
+daemon options.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Optional
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="agentopt",
+        description="agentopt — LLM model selection + per-call tracking",
+    )
+    subs = parser.add_subparsers(dest="cmd", required=True)
+    subs.add_parser(
+        "serve",
+        help="Run the long-lived gateway daemon. See `agentopt serve --help`.",
+        add_help=False,
+    )
+    # Parse only the first positional so subcommands can own their own flags.
+    args, rest = parser.parse_known_args(argv)
+
+    if args.cmd == "serve":
+        from .proxy.daemon import cli as serve_cli
+
+        serve_cli(rest)
+        return
+
+    parser.error(f"unknown subcommand: {args.cmd!r}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/agentopt/proxy/_backend.py
+++ b/src/agentopt/proxy/_backend.py
@@ -100,7 +100,23 @@ class _Backend(ABC):
 
     @abstractmethod
     def stop(self) -> None:
-        """Tear down all sessions and flush state."""
+        """Tear down all sessions and flush state.
+
+        Record queries (``get_records`` / ``get_usage`` / etc.) remain
+        valid after ``stop()`` so callers can harvest the run's records;
+        :meth:`close` is the final-teardown hook that releases everything
+        else (e.g. the remote backend's HTTP client).
+        """
+
+    def close(self) -> None:
+        """Release every resource the backend holds.  Idempotent.
+
+        Default implementation calls :meth:`stop` if the backend is
+        still active.  Subclasses that hold additional resources (long-
+        lived HTTP clients, sockets, threads) override to release them.
+        """
+        if getattr(self, "_active", False):
+            self.stop()
 
     # -- session management ------------------------------------------
 

--- a/src/agentopt/proxy/_backend.py
+++ b/src/agentopt/proxy/_backend.py
@@ -1,45 +1,34 @@
 """Backend abstraction for :class:`LLMTracker`.
 
 ``LLMTracker`` delegates every operation to a ``_Backend`` instance.  Two
-implementations live in the proxy package:
+implementations ship as siblings of this module:
 
-* :class:`LocalBackend` — runs the mitmproxy ``SessionMaster`` in the
-  current Python process (the original ``LLMTracker`` behaviour).
-* :class:`RemoteBackend` (see :mod:`._remote_backend`) — talks to a
-  long-lived ``agentopt serve`` daemon over HTTP.
+* :class:`._local_backend.LocalBackend` — runs the mitmproxy
+  ``SessionMaster`` in the current Python process.
+* :class:`._remote_backend.RemoteBackend` — talks to a long-lived
+  ``agentopt serve`` daemon over HTTP.
 
 The choice is made in :class:`LLMTracker.__init__` based on whether the
-``AGENTOPT_GATEWAY_URL`` environment variable is set.
+``AGENTOPT_GATEWAY_URL`` environment variable is set.  Both backends
+share the same public surface so ``ModelSelector`` (and any other
+``LLMTracker`` user) is unaware of which one is active.
 
-The two backends share the same public surface so ``ModelSelector`` (and
-any other ``LLMTracker`` user) is unaware of which one is active.
+This module owns only the abstract surface and CA-bundle helpers shared
+by both backends.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import threading
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import certifi
 
-from .cache import ResponseCache
-from .interceptor import (
-    ActiveSession,
-    LocalHandler,
-    _active_session_var,
-    install_redirect,
-    uninstall_redirect,
-)
-from .mitm_runner import SessionMaster
 from .models import CallRecord
-from .providers import ProviderRegistry
-from .recording import Recorder
-from .session import SessionInfo, SessionManager
+from .session import SessionInfo
 
 logger = logging.getLogger(__name__)
 
@@ -175,252 +164,3 @@ class _Backend(ABC):
     @abstractmethod
     def clear(self) -> None:
         """Clear all locally archived records."""
-
-
-# ---------------------------------------------------------------------------
-# LocalBackend — today's in-process behaviour
-# ---------------------------------------------------------------------------
-
-
-class LocalBackend(_Backend):
-    """In-process backend: per-session mitmproxy + httpx monkey-patch.
-
-    This is the original :class:`LLMTracker` implementation, extracted
-    behind :class:`_Backend` so a ``RemoteBackend`` can live alongside it
-    without forking the tracker's public surface.
-    """
-
-    _DEFAULT_CACHE_DIR = ".agentopt_cache"
-
-    def __init__(
-        self,
-        cache: bool = True,
-        cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
-    ) -> None:
-        self._records: List[CallRecord] = []
-        self._lock = threading.Lock()
-        self._active = False
-        self._response_cache = ResponseCache(cache_dir=cache_dir) if cache else None
-        self._session_manager = SessionManager()
-        self._registry = ProviderRegistry()
-        self._recorder = Recorder(self._session_manager)
-        # session_id -> SessionMaster
-        self._masters: Dict[str, SessionMaster] = {}
-        self._masters_lock = threading.Lock()
-
-    # -- lifecycle ----------------------------------------------------
-
-    def start(self) -> None:
-        """Install the httpx redirect.  Subprocess masters spin up per-track()."""
-        if self._active:
-            return
-        install_redirect()
-        self._active = True
-
-    def stop(self) -> None:
-        """Tear down all live SessionMasters, restore httpx, flush cache."""
-        if not self._active:
-            return
-        uninstall_redirect()
-        # Stop any masters that survived (track() should have closed them,
-        # but in test/error paths they may linger).
-        with self._masters_lock:
-            masters = list(self._masters.values())
-            self._masters.clear()
-        for m in masters:
-            try:
-                m.stop()
-            except Exception:
-                logger.debug("ignored exception in SessionMaster.stop", exc_info=True)
-        self._session_manager.force_end_all()
-        with self._lock:
-            self._records.extend(self._session_manager.get_all_records())
-        if self._response_cache is not None:
-            self._response_cache.close()
-        self._active = False
-
-    # -- session management ------------------------------------------
-
-    def open_session(
-        self,
-        data_id: Optional[str] = None,
-        combo_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> Tuple[SessionInfo, int]:
-        """Create a session + start its ``SessionMaster``.  No ContextVar.
-
-        Imperative counterpart to :meth:`track`.  Used by the daemon
-        (:mod:`.daemon`) where session lifecycle is driven by HTTP
-        endpoints, not a context manager.
-        """
-        assert self._active, "call backend.start() first"
-        session = self._session_manager.create_session(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
-        )
-        master = SessionMaster(
-            session=session,
-            registry=self._registry,
-            recorder=self._recorder,
-            cache=self._response_cache,
-        )
-        try:
-            port = master.start()
-            with self._masters_lock:
-                self._masters[session.session_id] = master
-        except Exception:
-            try:
-                master.stop()
-            except Exception:
-                logger.exception(
-                    "Failed to stop SessionMaster after startup failure for session %s",
-                    session.session_id,
-                )
-            finally:
-                self._session_manager.end_session(session.session_id)
-            raise
-        return session, port
-
-    def close_session(self, session_id: str) -> None:
-        """Stop the session's ``SessionMaster`` and archive its records."""
-        with self._masters_lock:
-            m = self._masters.pop(session_id, None)
-        if m is not None:
-            m.stop()
-        self._session_manager.end_session(session_id)
-
-    @contextmanager
-    def track(
-        self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
-    ) -> Iterator[SessionInfo]:
-        """Create a tracking session with its own mitmproxy port.
-
-        Sets the ``_active_session_var`` ContextVar so the in-process
-        httpx patch records calls into this session.  Eagerly starts a
-        ``SessionMaster`` so subprocesses can use ``get_session_env``
-        without further setup.
-        """
-        session, port = self.open_session(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
-        )
-        handler = LocalHandler(
-            session=session, recorder=self._recorder, cache=self._response_cache,
-        )
-        active = ActiveSession(
-            session=session,
-            port=port,
-            path_patterns=self._registry.path_patterns,
-            handler=handler,
-        )
-        token = _active_session_var.set(active)
-
-        try:
-            yield session
-        finally:
-            _active_session_var.reset(token)
-            self.close_session(session.session_id)
-
-    def get_session_env(self, session: SessionInfo) -> Dict[str, str]:
-        """Return env vars that route a subprocess through this session's port."""
-        with self._masters_lock:
-            master = self._masters.get(session.session_id)
-        assert master is not None, (
-            f"no SessionMaster for {session.session_id}; "
-            "is the session inside its track() scope?"
-        )
-        bundle = _ensure_ca_bundle()
-        return {
-            "HTTPS_PROXY": f"http://127.0.0.1:{master.port}",
-            "SSL_CERT_FILE": bundle,
-            "REQUESTS_CA_BUNDLE": bundle,
-            "NODE_EXTRA_CA_CERTS": bundle,
-        }
-
-    # -- provider registry -------------------------------------------
-
-    def register_provider(
-        self, name: str, base_url: str, path_patterns: tuple,
-    ) -> None:
-        """Add or replace a provider.
-
-        The shared ``ProviderRegistry`` is updated for both interception
-        paths: the subprocess addon sees the new intercept hostname
-        immediately via the shared reference, and the in-process httpx
-        patch picks up the new path patterns at the next ``track()``
-        entry (which snapshots ``registry.path_patterns`` onto the
-        ``ActiveSession``).
-        """
-        self._registry.register(name, base_url, path_patterns)
-
-    # -- cache management --------------------------------------------
-
-    def flush_cache(self) -> None:
-        """Flush dirty cache entries to disk immediately."""
-        if self._response_cache is not None:
-            self._response_cache.flush()
-
-    def clear_cache(self) -> None:
-        """Clear all cached responses and database rows."""
-        if self._response_cache is not None:
-            self._response_cache.clear()
-
-    # -- record queries ----------------------------------------------
-
-    def _all_records(self) -> List[CallRecord]:
-        """Gather records from both the local archive and live sessions."""
-        with self._lock:
-            records = list(self._records)
-        records.extend(self._session_manager.get_all_records())
-        return records
-
-    def get_records(
-        self,
-        data_id: Optional[str] = None,
-        combo_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> List[CallRecord]:
-        """Return ``CallRecord`` list, filtered by any combination of IDs."""
-        result = []
-        for r in self._all_records():
-            if data_id is not None and r.data_id != data_id:
-                continue
-            if combo_id is not None and r.combo_id != combo_id:
-                continue
-            if agent_id is not None and r.agent_id != agent_id:
-                continue
-            result.append(r)
-        return result
-
-    def get_usage(
-        self,
-        data_id: Optional[str] = None,
-        combo_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> Dict[str, Tuple[int, int]]:
-        """Return aggregated ``{model: (input_tokens, output_tokens)}``."""
-        records = self.get_records(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id
-        )
-        totals: Dict[str, List[int]] = {}
-        for r in records:
-            if r.model not in totals:
-                totals[r.model] = [0, 0]
-            totals[r.model][0] += r.prompt_tokens
-            totals[r.model][1] += r.completion_tokens
-        return {k: (v[0], v[1]) for k, v in totals.items()}
-
-    def get_cached_latency(
-        self,
-        data_id: Optional[str] = None,
-        combo_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> float:
-        """Return total latency (seconds) from cached responses."""
-        records = self.get_records(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id
-        )
-        return sum(r.latency_seconds for r in records if r.cached)
-
-    def clear(self) -> None:
-        """Clear all locally archived records."""
-        with self._lock:
-            self._records.clear()

--- a/src/agentopt/proxy/_backend.py
+++ b/src/agentopt/proxy/_backend.py
@@ -1,0 +1,426 @@
+"""Backend abstraction for :class:`LLMTracker`.
+
+``LLMTracker`` delegates every operation to a ``_Backend`` instance.  Two
+implementations live in the proxy package:
+
+* :class:`LocalBackend` — runs the mitmproxy ``SessionMaster`` in the
+  current Python process (the original ``LLMTracker`` behaviour).
+* :class:`RemoteBackend` (see :mod:`._remote_backend`) — talks to a
+  long-lived ``agentopt serve`` daemon over HTTP.
+
+The choice is made in :class:`LLMTracker.__init__` based on whether the
+``AGENTOPT_GATEWAY_URL`` environment variable is set.
+
+The two backends share the same public surface so ``ModelSelector`` (and
+any other ``LLMTracker`` user) is unaware of which one is active.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple, Union
+
+import certifi
+
+from .cache import ResponseCache
+from .interceptor import (
+    ActiveSession,
+    LocalHandler,
+    _active_session_var,
+    install_redirect,
+    uninstall_redirect,
+)
+from .mitm_runner import SessionMaster
+from .models import CallRecord
+from .providers import ProviderRegistry
+from .recording import Recorder
+from .session import SessionInfo, SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CA bundle helpers (shared by both backends — clients always need the bundle
+# to verify mitmproxy-impersonated upstream LLM hosts).
+# ---------------------------------------------------------------------------
+
+# mitmproxy's confdir defaults to ~/.mitmproxy.  We don't override it —
+# users may already have a mitmproxy CA installed in their browser/system
+# keychain, and reusing it avoids re-prompting them.
+_MITMPROXY_CONFDIR = Path(os.path.expanduser("~/.mitmproxy"))
+_MITMPROXY_CA_CERT = _MITMPROXY_CONFDIR / "mitmproxy-ca-cert.pem"
+# Where we write the merged bundle (mitmproxy CA + system CAs from certifi).
+# Subprocesses set SSL_CERT_FILE to this so they can verify *both*
+# mitmproxy-impersonated LLM hosts AND real (passthrough) hosts.
+_AGENTOPT_BUNDLE = _MITMPROXY_CONFDIR / "agentopt-bundle.pem"
+
+
+def _ensure_ca_bundle() -> str:
+    """Return path to a CA bundle = mitmproxy CA + certifi system CAs.
+
+    Subprocesses need this — setting ``SSL_CERT_FILE`` to mitmproxy's CA
+    alone would break verification for any host the proxy *doesn't* MITM
+    (passthrough hosts that the subprocess talks to directly).
+
+    Idempotent: if the bundle is already up to date with mitmproxy's CA,
+    no work is done.
+    """
+    if not _MITMPROXY_CA_CERT.exists():
+        raise RuntimeError(
+            f"mitmproxy CA cert not found at {_MITMPROXY_CA_CERT}. "
+            "Has any SessionMaster started yet?"
+        )
+
+    ca_mtime = _MITMPROXY_CA_CERT.stat().st_mtime
+    if _AGENTOPT_BUNDLE.exists() and _AGENTOPT_BUNDLE.stat().st_mtime >= ca_mtime:
+        return str(_AGENTOPT_BUNDLE)
+
+    with open(certifi.where(), "rb") as f:
+        system_pem = f.read()
+    with open(_MITMPROXY_CA_CERT, "rb") as f:
+        mitm_pem = f.read()
+
+    # Append rather than prepend so existing trust roots take precedence.
+    _AGENTOPT_BUNDLE.write_bytes(system_pem + b"\n" + mitm_pem)
+    return str(_AGENTOPT_BUNDLE)
+
+
+# ---------------------------------------------------------------------------
+# _Backend ABC
+# ---------------------------------------------------------------------------
+
+
+class _Backend(ABC):
+    """Internal interface used by :class:`LLMTracker`.
+
+    Implementations own the proxy lifecycle, session attribution, records,
+    cache, and provider registry.  Public methods mirror ``LLMTracker``'s
+    surface so the tracker is a thin delegator.
+    """
+
+    # -- lifecycle ----------------------------------------------------
+
+    @abstractmethod
+    def start(self) -> None:
+        """Prepare the backend for ``track()`` calls."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Tear down all sessions and flush state."""
+
+    # -- session management ------------------------------------------
+
+    @abstractmethod
+    def track(
+        self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
+    ):
+        """Return a context manager that yields a :class:`SessionInfo`."""
+
+    @abstractmethod
+    def get_session_env(self, session: SessionInfo) -> Dict[str, str]:
+        """Env vars that route a subprocess through this session's proxy."""
+
+    # -- provider registry -------------------------------------------
+
+    @abstractmethod
+    def register_provider(
+        self, name: str, base_url: str, path_patterns: tuple,
+    ) -> None:
+        """Add or replace an LLM provider."""
+
+    # -- cache management --------------------------------------------
+
+    @abstractmethod
+    def flush_cache(self) -> None:
+        """Force-flush any dirty cache entries to disk."""
+
+    @abstractmethod
+    def clear_cache(self) -> None:
+        """Delete all cached responses."""
+
+    # -- record queries ----------------------------------------------
+
+    @abstractmethod
+    def get_records(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> List[CallRecord]:
+        """Return ``CallRecord`` list, filtered by any combination of IDs."""
+
+    @abstractmethod
+    def get_usage(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Tuple[int, int]]:
+        """Return aggregated ``{model: (input_tokens, output_tokens)}``."""
+
+    @abstractmethod
+    def get_cached_latency(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> float:
+        """Return total latency (seconds) from cached responses."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear all locally archived records."""
+
+
+# ---------------------------------------------------------------------------
+# LocalBackend — today's in-process behaviour
+# ---------------------------------------------------------------------------
+
+
+class LocalBackend(_Backend):
+    """In-process backend: per-session mitmproxy + httpx monkey-patch.
+
+    This is the original :class:`LLMTracker` implementation, extracted
+    behind :class:`_Backend` so a ``RemoteBackend`` can live alongside it
+    without forking the tracker's public surface.
+    """
+
+    _DEFAULT_CACHE_DIR = ".agentopt_cache"
+
+    def __init__(
+        self,
+        cache: bool = True,
+        cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
+    ) -> None:
+        self._records: List[CallRecord] = []
+        self._lock = threading.Lock()
+        self._active = False
+        self._response_cache = ResponseCache(cache_dir=cache_dir) if cache else None
+        self._session_manager = SessionManager()
+        self._registry = ProviderRegistry()
+        self._recorder = Recorder(self._session_manager)
+        # session_id -> SessionMaster
+        self._masters: Dict[str, SessionMaster] = {}
+        self._masters_lock = threading.Lock()
+
+    # -- lifecycle ----------------------------------------------------
+
+    def start(self) -> None:
+        """Install the httpx redirect.  Subprocess masters spin up per-track()."""
+        if self._active:
+            return
+        install_redirect()
+        self._active = True
+
+    def stop(self) -> None:
+        """Tear down all live SessionMasters, restore httpx, flush cache."""
+        if not self._active:
+            return
+        uninstall_redirect()
+        # Stop any masters that survived (track() should have closed them,
+        # but in test/error paths they may linger).
+        with self._masters_lock:
+            masters = list(self._masters.values())
+            self._masters.clear()
+        for m in masters:
+            try:
+                m.stop()
+            except Exception:
+                logger.debug("ignored exception in SessionMaster.stop", exc_info=True)
+        self._session_manager.force_end_all()
+        with self._lock:
+            self._records.extend(self._session_manager.get_all_records())
+        if self._response_cache is not None:
+            self._response_cache.close()
+        self._active = False
+
+    # -- session management ------------------------------------------
+
+    def open_session(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[SessionInfo, int]:
+        """Create a session + start its ``SessionMaster``.  No ContextVar.
+
+        Imperative counterpart to :meth:`track`.  Used by the daemon
+        (:mod:`.daemon`) where session lifecycle is driven by HTTP
+        endpoints, not a context manager.
+        """
+        assert self._active, "call backend.start() first"
+        session = self._session_manager.create_session(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
+        master = SessionMaster(
+            session=session,
+            registry=self._registry,
+            recorder=self._recorder,
+            cache=self._response_cache,
+        )
+        try:
+            port = master.start()
+            with self._masters_lock:
+                self._masters[session.session_id] = master
+        except Exception:
+            try:
+                master.stop()
+            except Exception:
+                logger.exception(
+                    "Failed to stop SessionMaster after startup failure for session %s",
+                    session.session_id,
+                )
+            finally:
+                self._session_manager.end_session(session.session_id)
+            raise
+        return session, port
+
+    def close_session(self, session_id: str) -> None:
+        """Stop the session's ``SessionMaster`` and archive its records."""
+        with self._masters_lock:
+            m = self._masters.pop(session_id, None)
+        if m is not None:
+            m.stop()
+        self._session_manager.end_session(session_id)
+
+    @contextmanager
+    def track(
+        self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
+    ) -> Iterator[SessionInfo]:
+        """Create a tracking session with its own mitmproxy port.
+
+        Sets the ``_active_session_var`` ContextVar so the in-process
+        httpx patch records calls into this session.  Eagerly starts a
+        ``SessionMaster`` so subprocesses can use ``get_session_env``
+        without further setup.
+        """
+        session, port = self.open_session(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
+        handler = LocalHandler(
+            session=session, recorder=self._recorder, cache=self._response_cache,
+        )
+        active = ActiveSession(
+            session=session,
+            port=port,
+            path_patterns=self._registry.path_patterns,
+            handler=handler,
+        )
+        token = _active_session_var.set(active)
+
+        try:
+            yield session
+        finally:
+            _active_session_var.reset(token)
+            self.close_session(session.session_id)
+
+    def get_session_env(self, session: SessionInfo) -> Dict[str, str]:
+        """Return env vars that route a subprocess through this session's port."""
+        with self._masters_lock:
+            master = self._masters.get(session.session_id)
+        assert master is not None, (
+            f"no SessionMaster for {session.session_id}; "
+            "is the session inside its track() scope?"
+        )
+        bundle = _ensure_ca_bundle()
+        return {
+            "HTTPS_PROXY": f"http://127.0.0.1:{master.port}",
+            "SSL_CERT_FILE": bundle,
+            "REQUESTS_CA_BUNDLE": bundle,
+            "NODE_EXTRA_CA_CERTS": bundle,
+        }
+
+    # -- provider registry -------------------------------------------
+
+    def register_provider(
+        self, name: str, base_url: str, path_patterns: tuple,
+    ) -> None:
+        """Add or replace a provider.
+
+        The shared ``ProviderRegistry`` is updated for both interception
+        paths: the subprocess addon sees the new intercept hostname
+        immediately via the shared reference, and the in-process httpx
+        patch picks up the new path patterns at the next ``track()``
+        entry (which snapshots ``registry.path_patterns`` onto the
+        ``ActiveSession``).
+        """
+        self._registry.register(name, base_url, path_patterns)
+
+    # -- cache management --------------------------------------------
+
+    def flush_cache(self) -> None:
+        """Flush dirty cache entries to disk immediately."""
+        if self._response_cache is not None:
+            self._response_cache.flush()
+
+    def clear_cache(self) -> None:
+        """Clear all cached responses and database rows."""
+        if self._response_cache is not None:
+            self._response_cache.clear()
+
+    # -- record queries ----------------------------------------------
+
+    def _all_records(self) -> List[CallRecord]:
+        """Gather records from both the local archive and live sessions."""
+        with self._lock:
+            records = list(self._records)
+        records.extend(self._session_manager.get_all_records())
+        return records
+
+    def get_records(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> List[CallRecord]:
+        """Return ``CallRecord`` list, filtered by any combination of IDs."""
+        result = []
+        for r in self._all_records():
+            if data_id is not None and r.data_id != data_id:
+                continue
+            if combo_id is not None and r.combo_id != combo_id:
+                continue
+            if agent_id is not None and r.agent_id != agent_id:
+                continue
+            result.append(r)
+        return result
+
+    def get_usage(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Tuple[int, int]]:
+        """Return aggregated ``{model: (input_tokens, output_tokens)}``."""
+        records = self.get_records(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        )
+        totals: Dict[str, List[int]] = {}
+        for r in records:
+            if r.model not in totals:
+                totals[r.model] = [0, 0]
+            totals[r.model][0] += r.prompt_tokens
+            totals[r.model][1] += r.completion_tokens
+        return {k: (v[0], v[1]) for k, v in totals.items()}
+
+    def get_cached_latency(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> float:
+        """Return total latency (seconds) from cached responses."""
+        records = self.get_records(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        )
+        return sum(r.latency_seconds for r in records if r.cached)
+
+    def clear(self) -> None:
+        """Clear all locally archived records."""
+        with self._lock:
+            self._records.clear()

--- a/src/agentopt/proxy/_local_backend.py
+++ b/src/agentopt/proxy/_local_backend.py
@@ -1,0 +1,274 @@
+"""Local backend — runs the mitmproxy ``SessionMaster`` in this process.
+
+The original ``LLMTracker`` implementation, lifted behind the
+:class:`_Backend` interface so :class:`._remote_backend.RemoteBackend`
+can ship as a sibling.  The daemon (:mod:`.daemon`) wraps a singleton
+of this class to expose the surface over HTTP.
+
+Nothing in this module reaches outside the proxy package — :mod:`._backend`
+owns the ABC and the shared CA-bundle helpers.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple, Union
+
+from ._backend import _Backend, _ensure_ca_bundle
+from .cache import ResponseCache
+from .interceptor import (
+    ActiveSession,
+    LocalHandler,
+    _active_session_var,
+    install_redirect,
+    uninstall_redirect,
+)
+from .mitm_runner import SessionMaster
+from .models import CallRecord
+from .providers import ProviderRegistry
+from .recording import Recorder
+from .session import SessionInfo, SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+class LocalBackend(_Backend):
+    """In-process backend: per-session mitmproxy + httpx monkey-patch."""
+
+    _DEFAULT_CACHE_DIR = ".agentopt_cache"
+
+    def __init__(
+        self,
+        cache: bool = True,
+        cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
+    ) -> None:
+        self._records: List[CallRecord] = []
+        self._lock = threading.Lock()
+        self._active = False
+        self._response_cache = ResponseCache(cache_dir=cache_dir) if cache else None
+        self._session_manager = SessionManager()
+        self._registry = ProviderRegistry()
+        self._recorder = Recorder(self._session_manager)
+        # session_id -> SessionMaster
+        self._masters: Dict[str, SessionMaster] = {}
+        self._masters_lock = threading.Lock()
+
+    # -- lifecycle ----------------------------------------------------
+
+    def start(self) -> None:
+        """Install the httpx redirect.  Subprocess masters spin up per-track()."""
+        if self._active:
+            return
+        install_redirect()
+        self._active = True
+
+    def stop(self) -> None:
+        """Tear down all live SessionMasters, restore httpx, flush cache."""
+        if not self._active:
+            return
+        uninstall_redirect()
+        # Stop any masters that survived (track() should have closed them,
+        # but in test/error paths they may linger).
+        with self._masters_lock:
+            masters = list(self._masters.values())
+            self._masters.clear()
+        for m in masters:
+            try:
+                m.stop()
+            except Exception:
+                logger.debug("ignored exception in SessionMaster.stop", exc_info=True)
+        self._session_manager.force_end_all()
+        with self._lock:
+            self._records.extend(self._session_manager.get_all_records())
+        if self._response_cache is not None:
+            self._response_cache.close()
+        self._active = False
+
+    # -- session management ------------------------------------------
+
+    def open_session(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[SessionInfo, int]:
+        """Create a session + start its ``SessionMaster``.  No ContextVar.
+
+        Imperative counterpart to :meth:`track`.  Used by the daemon
+        (:mod:`.daemon`) where session lifecycle is driven by HTTP
+        endpoints, not a context manager.
+        """
+        assert self._active, "call backend.start() first"
+        session = self._session_manager.create_session(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
+        master = SessionMaster(
+            session=session,
+            registry=self._registry,
+            recorder=self._recorder,
+            cache=self._response_cache,
+        )
+        try:
+            port = master.start()
+            with self._masters_lock:
+                self._masters[session.session_id] = master
+        except Exception:
+            try:
+                master.stop()
+            except Exception:
+                logger.exception(
+                    "Failed to stop SessionMaster after startup failure for session %s",
+                    session.session_id,
+                )
+            finally:
+                self._session_manager.end_session(session.session_id)
+            raise
+        return session, port
+
+    def close_session(self, session_id: str) -> None:
+        """Stop the session's ``SessionMaster`` and archive its records."""
+        with self._masters_lock:
+            m = self._masters.pop(session_id, None)
+        if m is not None:
+            m.stop()
+        self._session_manager.end_session(session_id)
+
+    @contextmanager
+    def track(
+        self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
+    ) -> Iterator[SessionInfo]:
+        """Create a tracking session with its own mitmproxy port.
+
+        Sets the ``_active_session_var`` ContextVar so the in-process
+        httpx patch records calls into this session.  Eagerly starts a
+        ``SessionMaster`` so subprocesses can use ``get_session_env``
+        without further setup.
+        """
+        session, port = self.open_session(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
+        handler = LocalHandler(
+            session=session, recorder=self._recorder, cache=self._response_cache,
+        )
+        active = ActiveSession(
+            session=session,
+            port=port,
+            path_patterns=self._registry.path_patterns,
+            handler=handler,
+        )
+        token = _active_session_var.set(active)
+
+        try:
+            yield session
+        finally:
+            _active_session_var.reset(token)
+            self.close_session(session.session_id)
+
+    def get_session_env(self, session: SessionInfo) -> Dict[str, str]:
+        """Return env vars that route a subprocess through this session's port."""
+        with self._masters_lock:
+            master = self._masters.get(session.session_id)
+        assert master is not None, (
+            f"no SessionMaster for {session.session_id}; "
+            "is the session inside its track() scope?"
+        )
+        bundle = _ensure_ca_bundle()
+        return {
+            "HTTPS_PROXY": f"http://127.0.0.1:{master.port}",
+            "SSL_CERT_FILE": bundle,
+            "REQUESTS_CA_BUNDLE": bundle,
+            "NODE_EXTRA_CA_CERTS": bundle,
+        }
+
+    # -- provider registry -------------------------------------------
+
+    def register_provider(
+        self, name: str, base_url: str, path_patterns: tuple,
+    ) -> None:
+        """Add or replace a provider.
+
+        The shared ``ProviderRegistry`` is updated for both interception
+        paths: the subprocess addon sees the new intercept hostname
+        immediately via the shared reference, and the in-process httpx
+        patch picks up the new path patterns at the next ``track()``
+        entry (which snapshots ``registry.path_patterns`` onto the
+        ``ActiveSession``).
+        """
+        self._registry.register(name, base_url, path_patterns)
+
+    # -- cache management --------------------------------------------
+
+    def flush_cache(self) -> None:
+        """Flush dirty cache entries to disk immediately."""
+        if self._response_cache is not None:
+            self._response_cache.flush()
+
+    def clear_cache(self) -> None:
+        """Clear all cached responses and database rows."""
+        if self._response_cache is not None:
+            self._response_cache.clear()
+
+    # -- record queries ----------------------------------------------
+
+    def _all_records(self) -> List[CallRecord]:
+        """Gather records from both the local archive and live sessions."""
+        with self._lock:
+            records = list(self._records)
+        records.extend(self._session_manager.get_all_records())
+        return records
+
+    def get_records(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> List[CallRecord]:
+        """Return ``CallRecord`` list, filtered by any combination of IDs."""
+        result = []
+        for r in self._all_records():
+            if data_id is not None and r.data_id != data_id:
+                continue
+            if combo_id is not None and r.combo_id != combo_id:
+                continue
+            if agent_id is not None and r.agent_id != agent_id:
+                continue
+            result.append(r)
+        return result
+
+    def get_usage(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Tuple[int, int]]:
+        """Return aggregated ``{model: (input_tokens, output_tokens)}``."""
+        records = self.get_records(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        )
+        totals: Dict[str, List[int]] = {}
+        for r in records:
+            if r.model not in totals:
+                totals[r.model] = [0, 0]
+            totals[r.model][0] += r.prompt_tokens
+            totals[r.model][1] += r.completion_tokens
+        return {k: (v[0], v[1]) for k, v in totals.items()}
+
+    def get_cached_latency(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> float:
+        """Return total latency (seconds) from cached responses."""
+        records = self.get_records(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        )
+        return sum(r.latency_seconds for r in records if r.cached)
+
+    def clear(self) -> None:
+        """Clear all locally archived records."""
+        with self._lock:
+            self._records.clear()

--- a/src/agentopt/proxy/_remote_backend.py
+++ b/src/agentopt/proxy/_remote_backend.py
@@ -20,6 +20,7 @@ No cache or records live in this process — the daemon owns both.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import logging
@@ -89,6 +90,25 @@ def _write_ca_bundle(ca_pem: bytes, gateway_url: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _make_httpx_client(
+    cls, proxy_url: str, ca_bundle_path: str,
+):
+    """Construct an httpx ``Client`` or ``AsyncClient`` with proxy config.
+
+    ``proxy=`` is the modern httpx kwarg (0.27+).  Fall back to the
+    deprecated ``proxies=`` for older installs (package pin is
+    ``httpx>=0.24``).
+    """
+    try:
+        return cls(proxy=proxy_url, verify=ca_bundle_path, timeout=_DEFAULT_TIMEOUT)
+    except TypeError:
+        return cls(
+            proxies={"all://": proxy_url},
+            verify=ca_bundle_path,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+
+
 class RemoteHandler(CallHandler):
     """Forward intercepted requests through the daemon's session proxy.
 
@@ -97,30 +117,22 @@ class RemoteHandler(CallHandler):
     OpenAI/Anthropic SDKs) still get their traffic captured when
     ``AGENTOPT_GATEWAY_URL`` is set; subprocess agents use
     ``HTTPS_PROXY`` directly and never hit this code.
+
+    The sync client is created eagerly; the async client is created on
+    first use.  This keeps the common (sync-only) path leak-free without
+    making the async path more expensive than necessary — and it gives
+    :meth:`close` a clear signal for when async cleanup is needed.
     """
 
     def __init__(self, proxy_url: str, ca_bundle_path: str) -> None:
-        # `proxy=` is the modern httpx kwarg (0.27+).  Fall back to
-        # the deprecated `proxies=` for older installs (package pin is
-        # httpx>=0.24).
-        try:
-            self._sync_client = httpx.Client(
-                proxy=proxy_url, verify=ca_bundle_path, timeout=_DEFAULT_TIMEOUT,
-            )
-            self._async_client = httpx.AsyncClient(
-                proxy=proxy_url, verify=ca_bundle_path, timeout=_DEFAULT_TIMEOUT,
-            )
-        except TypeError:
-            self._sync_client = httpx.Client(
-                proxies={"all://": proxy_url},
-                verify=ca_bundle_path,
-                timeout=_DEFAULT_TIMEOUT,
-            )
-            self._async_client = httpx.AsyncClient(
-                proxies={"all://": proxy_url},
-                verify=ca_bundle_path,
-                timeout=_DEFAULT_TIMEOUT,
-            )
+        self._proxy_url = proxy_url
+        self._ca_bundle_path = ca_bundle_path
+        self._sync_client: httpx.Client = _make_httpx_client(
+            httpx.Client, proxy_url, ca_bundle_path,
+        )
+        # Lazy: only created if handle_async is ever called.  Avoids
+        # leaking a connection pool when only sync paths are exercised.
+        self._async_client: Optional[httpx.AsyncClient] = None
 
     def handle_sync(
         self, client: httpx.Client, request: httpx.Request, *, stream: bool, **kwargs,
@@ -136,6 +148,10 @@ class RemoteHandler(CallHandler):
         stream: bool,
         **kwargs,
     ) -> httpx.Response:
+        if self._async_client is None:
+            self._async_client = _make_httpx_client(
+                httpx.AsyncClient, self._proxy_url, self._ca_bundle_path,
+            )
         return await forward_async(
             self._async_client, request, stream=stream, **kwargs,
         )
@@ -145,11 +161,42 @@ class RemoteHandler(CallHandler):
             self._sync_client.close()
         except Exception:
             logger.debug("ignored exception closing sync client", exc_info=True)
-        # AsyncClient.aclose() needs an event loop; best-effort sync close.
+        # Only attempt async cleanup if we actually built an async client.
+        # AsyncClient has no synchronous ``close`` — must drive ``aclose``
+        # on a loop.
+        if self._async_client is not None:
+            self._close_async_client(self._async_client)
+            self._async_client = None
+
+    @staticmethod
+    def _close_async_client(client: httpx.AsyncClient) -> None:
+        """Run ``client.aclose()`` regardless of whether a loop is current.
+
+        * No running loop → drive a fresh one via ``asyncio.run``.
+        * Running loop (e.g. ``track()`` exits inside ``asyncio.run(...)``)
+          → fire-and-forget a task on it; we can't ``await`` from sync
+          code, but the task will complete before the loop closes.
+        """
         try:
-            self._async_client.close()  # type: ignore[attr-defined]
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            try:
+                asyncio.run(client.aclose())
+            except Exception:
+                logger.debug(
+                    "ignored exception draining async client", exc_info=True,
+                )
+            return
+
+        try:
+            loop.create_task(client.aclose())
         except Exception:
-            logger.debug("ignored exception closing async client", exc_info=True)
+            logger.debug(
+                "ignored exception scheduling async client aclose", exc_info=True,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentopt/proxy/_remote_backend.py
+++ b/src/agentopt/proxy/_remote_backend.py
@@ -274,9 +274,35 @@ class RemoteBackend(_Backend):
         # NOTE: do not close ``self._http`` here.  Callers (``ModelSelector``
         # in particular) invoke ``get_records()`` / ``get_usage()`` *after*
         # ``stop()`` to harvest the run's records — those calls would fail
-        # against a closed control-plane client.  The httpx Client closes
-        # itself in __del__ when the backend is garbage-collected.
+        # against a closed control-plane client.  Use :meth:`close` for
+        # final teardown.
         self._active = False
+
+    def close(self) -> None:
+        """Final teardown.  Idempotent; safe to call after ``stop``.
+
+        Releases the control-plane httpx client.  Without this, httpx
+        emits an "Unclosed client" warning at GC time, and on PyPy or
+        in cycles the close may run much later than expected.
+        """
+        if self._active:
+            self.stop()
+        try:
+            if not self._http.is_closed:
+                self._http.close()
+        except Exception:
+            logger.debug(
+                "ignored exception closing control-plane client", exc_info=True,
+            )
+
+    def __del__(self) -> None:
+        # Safety net for callers that forget to call ``close()``.  Errors
+        # from __del__ are awkward — swallow them rather than print to
+        # stderr at interpreter shutdown.
+        try:
+            self.close()
+        except Exception:
+            pass
 
     # -- session management ------------------------------------------
 

--- a/src/agentopt/proxy/_remote_backend.py
+++ b/src/agentopt/proxy/_remote_backend.py
@@ -1,0 +1,398 @@
+"""Remote backend — talks to a long-lived ``agentopt serve`` daemon.
+
+Selected when ``LLMTracker`` is constructed with the
+``AGENTOPT_GATEWAY_URL`` env var set.  Surface mirrors :class:`LocalBackend`;
+every operation maps to one HTTP call against the daemon's control plane
+(see :mod:`.daemon`).
+
+Per-session state held client-side:
+
+* ``proxy_port`` — the daemon-allocated per-session port that
+  ``HTTPS_PROXY`` and the in-process :class:`RemoteHandler`'s httpx client
+  point at.
+* ``ca_bundle_path`` — a per-gateway file combining certifi system CAs
+  with the daemon's mitmproxy CA.  Subprocess agents get its path via
+  :meth:`get_session_env`; the in-process handler hands it to httpx as
+  ``verify=``.
+
+No cache or records live in this process — the daemon owns both.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+import certifi
+import httpx
+
+from ._backend import _Backend
+from .interceptor import (
+    ActiveSession,
+    CallHandler,
+    _active_session_var,
+    forward_async,
+    forward_sync,
+    install_redirect,
+    uninstall_redirect,
+)
+from .models import CallRecord
+from .providers import _BUILTIN_PROVIDERS
+from .session import SessionInfo
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_TIMEOUT = httpx.Timeout(300.0)  # generous; LLM calls can be slow
+
+
+# ---------------------------------------------------------------------------
+# CA bundle plumbing — write a per-gateway bundle file once
+# ---------------------------------------------------------------------------
+
+
+def _bundle_dir_for(gateway_url: str) -> Path:
+    """Per-gateway directory for the merged CA bundle.
+
+    Keyed by a short hash of the URL so two daemons on different hosts
+    keep their bundles separate.
+    """
+    h = hashlib.sha256(gateway_url.encode()).hexdigest()[:12]
+    d = Path.home() / ".agentopt" / "remote" / h
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_ca_bundle(ca_pem: bytes, gateway_url: str) -> str:
+    """Combine certifi system CAs + daemon CA, write to the bundle file.
+
+    Idempotent: if the file already contains an identical bundle, no
+    write happens.  Returns the absolute path as a string.
+    """
+    dest = _bundle_dir_for(gateway_url) / "ca-bundle.pem"
+    with open(certifi.where(), "rb") as f:
+        system_pem = f.read()
+    new_bytes = system_pem + b"\n" + ca_pem
+    if dest.exists() and dest.read_bytes() == new_bytes:
+        return str(dest)
+    dest.write_bytes(new_bytes)
+    return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# RemoteHandler — in-process httpx → daemon's per-session proxy port
+# ---------------------------------------------------------------------------
+
+
+class RemoteHandler(CallHandler):
+    """Forward intercepted requests through the daemon's session proxy.
+
+    No local cache, no local recording — the daemon does both.  This
+    handler exists so that *in-process* Python agents (using httpx via
+    OpenAI/Anthropic SDKs) still get their traffic captured when
+    ``AGENTOPT_GATEWAY_URL`` is set; subprocess agents use
+    ``HTTPS_PROXY`` directly and never hit this code.
+    """
+
+    def __init__(self, proxy_url: str, ca_bundle_path: str) -> None:
+        # `proxy=` is the modern httpx kwarg (0.27+).  Fall back to
+        # the deprecated `proxies=` for older installs (package pin is
+        # httpx>=0.24).
+        try:
+            self._sync_client = httpx.Client(
+                proxy=proxy_url, verify=ca_bundle_path, timeout=_DEFAULT_TIMEOUT,
+            )
+            self._async_client = httpx.AsyncClient(
+                proxy=proxy_url, verify=ca_bundle_path, timeout=_DEFAULT_TIMEOUT,
+            )
+        except TypeError:
+            self._sync_client = httpx.Client(
+                proxies={"all://": proxy_url},
+                verify=ca_bundle_path,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+            self._async_client = httpx.AsyncClient(
+                proxies={"all://": proxy_url},
+                verify=ca_bundle_path,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+
+    def handle_sync(
+        self, client: httpx.Client, request: httpx.Request, *, stream: bool, **kwargs,
+    ) -> httpx.Response:
+        # Use our proxy-configured client; bypass the patch via forward_sync.
+        return forward_sync(self._sync_client, request, stream=stream, **kwargs)
+
+    async def handle_async(
+        self,
+        client: httpx.AsyncClient,
+        request: httpx.Request,
+        *,
+        stream: bool,
+        **kwargs,
+    ) -> httpx.Response:
+        return await forward_async(
+            self._async_client, request, stream=stream, **kwargs,
+        )
+
+    def close(self) -> None:
+        try:
+            self._sync_client.close()
+        except Exception:
+            logger.debug("ignored exception closing sync client", exc_info=True)
+        # AsyncClient.aclose() needs an event loop; best-effort sync close.
+        try:
+            self._async_client.close()  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug("ignored exception closing async client", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# RemoteBackend
+# ---------------------------------------------------------------------------
+
+
+class _SessionState:
+    """Client-side per-session bookkeeping for ``get_session_env`` etc."""
+
+    __slots__ = ("proxy_port", "ca_bundle_path", "handler")
+
+    def __init__(self, proxy_port: int, ca_bundle_path: str, handler: RemoteHandler):
+        self.proxy_port = proxy_port
+        self.ca_bundle_path = ca_bundle_path
+        self.handler = handler
+
+
+class RemoteBackend(_Backend):
+    """Control-plane client for a long-lived ``agentopt serve`` daemon."""
+
+    def __init__(self, gateway_url: str) -> None:
+        self._gateway_url = gateway_url.rstrip("/")
+        # Extract host for building per-session proxy URLs (control-plane
+        # host == proxy host, by construction).
+        parsed = httpx.URL(self._gateway_url)
+        self._gateway_host = parsed.host
+        self._http = httpx.Client(timeout=httpx.Timeout(30.0))
+
+        # Local view of provider path patterns — drives the in-process
+        # interceptor's fast-path filter.  Built-ins are pre-loaded;
+        # custom providers added via register_provider() are appended and
+        # forwarded to the daemon.
+        self._path_patterns: Set[str] = set()
+        for p in _BUILTIN_PROVIDERS:
+            for pattern in p.path_patterns:
+                self._path_patterns.add(pattern)
+
+        self._sessions: Dict[str, _SessionState] = {}
+        self._sessions_lock = threading.Lock()
+        self._active = False
+
+    # -- lifecycle ----------------------------------------------------
+
+    def start(self) -> None:
+        if self._active:
+            return
+        install_redirect()
+        # Sanity: daemon reachable.  Fail fast with a clear message.
+        try:
+            r = self._http.get(f"{self._gateway_url}/health")
+            r.raise_for_status()
+        except httpx.HTTPError as exc:
+            uninstall_redirect()
+            raise RuntimeError(
+                f"agentopt: gateway at {self._gateway_url} is not reachable. "
+                "Is `agentopt serve` running, and is AGENTOPT_GATEWAY_URL "
+                f"correct?  ({exc})"
+            ) from exc
+        self._active = True
+
+    def stop(self) -> None:
+        if not self._active:
+            return
+        uninstall_redirect()
+        # Close any sessions that survived (well-behaved callers exit
+        # track() cleanly, but tests / error paths may not).
+        with self._sessions_lock:
+            ids = list(self._sessions.keys())
+        for sid in ids:
+            try:
+                self.close_session(sid)
+            except Exception:
+                logger.debug("ignored exception closing session %s", sid, exc_info=True)
+        # NOTE: do not close ``self._http`` here.  Callers (``ModelSelector``
+        # in particular) invoke ``get_records()`` / ``get_usage()`` *after*
+        # ``stop()`` to harvest the run's records — those calls would fail
+        # against a closed control-plane client.  The httpx Client closes
+        # itself in __del__ when the backend is garbage-collected.
+        self._active = False
+
+    # -- session management ------------------------------------------
+
+    def open_session(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[SessionInfo, int, str]:
+        """POST /sessions; return ``(SessionInfo, proxy_port, ca_bundle_path)``.
+
+        Exposed for parity with :meth:`LocalBackend.open_session` (and
+        for testability); :meth:`track` is the usual entry point.
+        """
+        assert self._active, "call backend.start() first"
+        resp = self._http.post(
+            f"{self._gateway_url}/sessions",
+            json={"data_id": data_id, "combo_id": combo_id, "agent_id": agent_id},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        session = SessionInfo(
+            session_id=body["session_id"],
+            data_id=data_id,
+            combo_id=combo_id,
+            agent_id=agent_id,
+        )
+        proxy_port = int(body["proxy_port"])
+        ca_pem = base64.b64decode(body["ca_pem_b64"])
+        bundle_path = _write_ca_bundle(ca_pem, self._gateway_url)
+        return session, proxy_port, bundle_path
+
+    def close_session(self, session_id: str) -> None:
+        """DELETE /sessions/{id} and drop client-side state."""
+        with self._sessions_lock:
+            state = self._sessions.pop(session_id, None)
+        if state is not None:
+            state.handler.close()
+        try:
+            self._http.delete(f"{self._gateway_url}/sessions/{session_id}")
+        except httpx.HTTPError:
+            logger.debug(
+                "ignored error closing remote session %s", session_id, exc_info=True,
+            )
+
+    @contextmanager
+    def track(
+        self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
+    ) -> Iterator[SessionInfo]:
+        session, proxy_port, bundle_path = self.open_session(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
+        proxy_url = f"http://{self._gateway_host}:{proxy_port}"
+        handler = RemoteHandler(proxy_url=proxy_url, ca_bundle_path=bundle_path)
+        with self._sessions_lock:
+            self._sessions[session.session_id] = _SessionState(
+                proxy_port=proxy_port, ca_bundle_path=bundle_path, handler=handler,
+            )
+
+        active = ActiveSession(
+            session=session,
+            port=proxy_port,
+            path_patterns=frozenset(self._path_patterns),
+            handler=handler,
+        )
+        token = _active_session_var.set(active)
+        try:
+            yield session
+        finally:
+            _active_session_var.reset(token)
+            self.close_session(session.session_id)
+
+    def get_session_env(self, session: SessionInfo) -> Dict[str, str]:
+        with self._sessions_lock:
+            state = self._sessions.get(session.session_id)
+        assert state is not None, (
+            f"no remote session state for {session.session_id}; "
+            "is the session inside its track() scope?"
+        )
+        proxy = f"http://{self._gateway_host}:{state.proxy_port}"
+        return {
+            "HTTPS_PROXY": proxy,
+            "SSL_CERT_FILE": state.ca_bundle_path,
+            "REQUESTS_CA_BUNDLE": state.ca_bundle_path,
+            "NODE_EXTRA_CA_CERTS": state.ca_bundle_path,
+        }
+
+    # -- provider registry -------------------------------------------
+
+    def register_provider(
+        self, name: str, base_url: str, path_patterns: tuple,
+    ) -> None:
+        self._path_patterns.update(path_patterns)
+        resp = self._http.post(
+            f"{self._gateway_url}/providers",
+            json={
+                "name": name,
+                "base_url": base_url,
+                "path_patterns": list(path_patterns),
+            },
+        )
+        resp.raise_for_status()
+
+    # -- cache management --------------------------------------------
+
+    def flush_cache(self) -> None:
+        self._http.post(f"{self._gateway_url}/cache/flush").raise_for_status()
+
+    def clear_cache(self) -> None:
+        self._http.post(f"{self._gateway_url}/cache/clear").raise_for_status()
+
+    # -- record queries ----------------------------------------------
+
+    def _query_params(
+        self, data_id: Optional[str], combo_id: Optional[str], agent_id: Optional[str],
+    ) -> Dict[str, str]:
+        params = {}
+        if data_id is not None:
+            params["data_id"] = data_id
+        if combo_id is not None:
+            params["combo_id"] = combo_id
+        if agent_id is not None:
+            params["agent_id"] = agent_id
+        return params
+
+    def get_records(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> List[CallRecord]:
+        resp = self._http.get(
+            f"{self._gateway_url}/records",
+            params=self._query_params(data_id, combo_id, agent_id),
+        )
+        resp.raise_for_status()
+        return [CallRecord(**d) for d in resp.json()]
+
+    def get_usage(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Tuple[int, int]]:
+        resp = self._http.get(
+            f"{self._gateway_url}/usage",
+            params=self._query_params(data_id, combo_id, agent_id),
+        )
+        resp.raise_for_status()
+        return {k: (int(v[0]), int(v[1])) for k, v in resp.json().items()}
+
+    def get_cached_latency(
+        self,
+        data_id: Optional[str] = None,
+        combo_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> float:
+        resp = self._http.get(
+            f"{self._gateway_url}/cached_latency",
+            params=self._query_params(data_id, combo_id, agent_id),
+        )
+        resp.raise_for_status()
+        return float(resp.json()["seconds"])
+
+    def clear(self) -> None:
+        """No-op for remote: client holds no record buffer."""

--- a/src/agentopt/proxy/daemon.py
+++ b/src/agentopt/proxy/daemon.py
@@ -33,7 +33,8 @@ from typing import Any, Dict, List, Optional
 
 from aiohttp import web
 
-from ._backend import _MITMPROXY_CA_CERT, LocalBackend
+from ._backend import _MITMPROXY_CA_CERT
+from ._local_backend import LocalBackend
 from .models import CallRecord
 
 logger = logging.getLogger(__name__)
@@ -50,11 +51,6 @@ _BACKEND_KEY = web.AppKey("backend", LocalBackend)
 def record_to_dict(r: CallRecord) -> Dict[str, Any]:
     """Serialize a ``CallRecord`` to a JSON-compatible dict."""
     return dataclasses.asdict(r)
-
-
-def record_from_dict(d: Dict[str, Any]) -> CallRecord:
-    """Reconstruct a ``CallRecord`` from a server-side dict."""
-    return CallRecord(**d)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentopt/proxy/daemon.py
+++ b/src/agentopt/proxy/daemon.py
@@ -1,0 +1,260 @@
+"""HTTP control plane for the long-lived ``agentopt serve`` daemon.
+
+The daemon owns a singleton :class:`LocalBackend` and exposes its surface
+over HTTP so any number of client processes (each holding a
+``RemoteBackend``) can share one set of sessions, records, and cache.
+
+Endpoints (localhost-only, JSON in/out)::
+
+    GET    /health                          → {"ok": true}
+    POST   /sessions                        → {session_id, proxy_port, ca_pem_b64}
+    DELETE /sessions/{session_id}           → 204
+    GET    /records?data_id=&combo_id=…     → [CallRecord, …]
+    GET    /usage?data_id=&…                → {model: [in, out]}
+    GET    /cached_latency?…                → {seconds: float}
+    POST   /cache/flush                     → 204
+    POST   /cache/clear                     → 204
+    POST   /providers                       → 204
+    GET    /ca                              → {ca_pem_b64}
+
+No auth, no TLS — bind 127.0.0.1 only.  ``--allow-remote`` is reserved
+for a future revision that adds authentication; until then, attempting
+to bind 0.0.0.0 fails fast.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import dataclasses
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiohttp import web
+
+from ._backend import _MITMPROXY_CA_CERT, LocalBackend
+from .models import CallRecord
+
+logger = logging.getLogger(__name__)
+
+
+_BACKEND_KEY = web.AppKey("backend", LocalBackend)
+
+
+# ---------------------------------------------------------------------------
+# CallRecord serialisation
+# ---------------------------------------------------------------------------
+
+
+def record_to_dict(r: CallRecord) -> Dict[str, Any]:
+    """Serialize a ``CallRecord`` to a JSON-compatible dict."""
+    return dataclasses.asdict(r)
+
+
+def record_from_dict(d: Dict[str, Any]) -> CallRecord:
+    """Reconstruct a ``CallRecord`` from a server-side dict."""
+    return CallRecord(**d)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint handlers
+# ---------------------------------------------------------------------------
+
+
+async def _health(request: web.Request) -> web.Response:
+    return web.json_response({"ok": True})
+
+
+async def _create_session(request: web.Request) -> web.Response:
+    body = await request.json() if request.body_exists else {}
+    backend = request.app[_BACKEND_KEY]
+    loop = asyncio.get_running_loop()
+    session, port = await loop.run_in_executor(
+        None,
+        backend.open_session,
+        body.get("data_id"),
+        body.get("combo_id"),
+        body.get("agent_id"),
+    )
+    ca_pem_b64 = _read_ca_pem_b64()
+    return web.json_response(
+        {
+            "session_id": session.session_id,
+            "proxy_port": port,
+            "ca_pem_b64": ca_pem_b64,
+        }
+    )
+
+
+async def _close_session(request: web.Request) -> web.Response:
+    sid = request.match_info["session_id"]
+    backend = request.app[_BACKEND_KEY]
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, backend.close_session, sid)
+    return web.Response(status=204)
+
+
+async def _get_records(request: web.Request) -> web.Response:
+    backend = request.app[_BACKEND_KEY]
+    records: List[CallRecord] = backend.get_records(
+        data_id=request.query.get("data_id"),
+        combo_id=request.query.get("combo_id"),
+        agent_id=request.query.get("agent_id"),
+    )
+    return web.json_response([record_to_dict(r) for r in records])
+
+
+async def _get_usage(request: web.Request) -> web.Response:
+    backend = request.app[_BACKEND_KEY]
+    usage = backend.get_usage(
+        data_id=request.query.get("data_id"),
+        combo_id=request.query.get("combo_id"),
+        agent_id=request.query.get("agent_id"),
+    )
+    return web.json_response({k: list(v) for k, v in usage.items()})
+
+
+async def _get_cached_latency(request: web.Request) -> web.Response:
+    backend = request.app[_BACKEND_KEY]
+    seconds = backend.get_cached_latency(
+        data_id=request.query.get("data_id"),
+        combo_id=request.query.get("combo_id"),
+        agent_id=request.query.get("agent_id"),
+    )
+    return web.json_response({"seconds": seconds})
+
+
+async def _flush_cache(request: web.Request) -> web.Response:
+    request.app[_BACKEND_KEY].flush_cache()
+    return web.Response(status=204)
+
+
+async def _clear_cache(request: web.Request) -> web.Response:
+    request.app[_BACKEND_KEY].clear_cache()
+    return web.Response(status=204)
+
+
+async def _register_provider(request: web.Request) -> web.Response:
+    body = await request.json()
+    request.app[_BACKEND_KEY].register_provider(
+        name=body["name"],
+        base_url=body["base_url"],
+        path_patterns=tuple(body["path_patterns"]),
+    )
+    return web.Response(status=204)
+
+
+async def _get_ca(request: web.Request) -> web.Response:
+    return web.json_response({"ca_pem_b64": _read_ca_pem_b64()})
+
+
+# ---------------------------------------------------------------------------
+# App / runner
+# ---------------------------------------------------------------------------
+
+
+def make_app(backend: LocalBackend) -> web.Application:
+    """Build the aiohttp application bound to *backend*."""
+    app = web.Application()
+    app[_BACKEND_KEY] = backend
+    app.router.add_get("/health", _health)
+    app.router.add_post("/sessions", _create_session)
+    app.router.add_delete("/sessions/{session_id}", _close_session)
+    app.router.add_get("/records", _get_records)
+    app.router.add_get("/usage", _get_usage)
+    app.router.add_get("/cached_latency", _get_cached_latency)
+    app.router.add_post("/cache/flush", _flush_cache)
+    app.router.add_post("/cache/clear", _clear_cache)
+    app.router.add_post("/providers", _register_provider)
+    app.router.add_get("/ca", _get_ca)
+    return app
+
+
+def _read_ca_pem_b64() -> str:
+    """Read and base64-encode mitmproxy's CA cert.
+
+    The CA file is generated by mitmproxy the first time a ``SessionMaster``
+    starts.  Daemon startup eagerly warms a throwaway session so this is
+    available before any client connects.
+    """
+    if not _MITMPROXY_CA_CERT.exists():
+        raise RuntimeError(
+            f"mitmproxy CA cert not found at {_MITMPROXY_CA_CERT}. "
+            "Daemon CA warmup must have failed."
+        )
+    return base64.b64encode(_MITMPROXY_CA_CERT.read_bytes()).decode("ascii")
+
+
+def _warmup_ca(backend: LocalBackend) -> None:
+    """Ensure mitmproxy's CA is generated by spinning a throwaway session.
+
+    Subsequent ``GET /ca`` and ``POST /sessions`` (which embed the CA)
+    can then return the cert immediately rather than 503ing the first
+    caller.
+    """
+    if _MITMPROXY_CA_CERT.exists():
+        return
+    logger.info("Warming up mitmproxy CA (one-time per machine)...")
+    session, _port = backend.open_session(
+        data_id="__warmup__", combo_id="__warmup__", agent_id=None,
+    )
+    backend.close_session(session.session_id)
+
+
+def run(
+    host: str = "127.0.0.1",
+    port: int = 9000,
+    cache_dir: Optional[str] = ".agentopt_cache",
+    allow_remote: bool = False,
+) -> None:
+    """Start the daemon and block until interrupted.
+
+    *host* defaults to ``127.0.0.1``; binding any other address requires
+    ``allow_remote=True``, which is reserved for a future revision that
+    ships authentication.  Until then, refusing fast is safer than
+    accidentally exposing an unauthenticated proxy on the network.
+    """
+    if host not in ("127.0.0.1", "localhost", "::1") and not allow_remote:
+        raise SystemExit(
+            f"refusing to bind {host!r}: agentopt serve is localhost-only "
+            "in this release (no auth).  Use --host 127.0.0.1, or pass "
+            "--allow-remote once authentication is wired up."
+        )
+
+    backend = LocalBackend(cache=True, cache_dir=cache_dir)
+    backend.start()
+    try:
+        _warmup_ca(backend)
+        app = make_app(backend)
+        logger.info("agentopt serve listening on http://%s:%d", host, port)
+        web.run_app(app, host=host, port=port, print=None, handle_signals=True)
+    finally:
+        backend.stop()
+
+
+def cli(argv: Optional[List[str]] = None) -> None:
+    """argparse entrypoint for the ``agentopt serve`` subcommand."""
+    parser = argparse.ArgumentParser(prog="agentopt serve")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9000)
+    parser.add_argument("--cache-dir", default=".agentopt_cache")
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="(reserved) bind a non-localhost host. Requires auth which is not yet shipped.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    run(
+        host=args.host,
+        port=args.port,
+        cache_dir=args.cache_dir,
+        allow_remote=args.allow_remote,
+    )

--- a/src/agentopt/proxy/daemon.py
+++ b/src/agentopt/proxy/daemon.py
@@ -29,7 +29,8 @@ import asyncio
 import base64
 import dataclasses
 import logging
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 from aiohttp import web
 
@@ -201,7 +202,7 @@ def _warmup_ca(backend: LocalBackend) -> None:
 def run(
     host: str = "127.0.0.1",
     port: int = 9000,
-    cache_dir: Optional[str] = ".agentopt_cache",
+    cache_dir: Union[str, Path] = ".agentopt_cache",
     allow_remote: bool = False,
 ) -> None:
     """Start the daemon and block until interrupted.
@@ -210,6 +211,12 @@ def run(
     ``allow_remote=True``, which is reserved for a future revision that
     ships authentication.  Until then, refusing fast is safer than
     accidentally exposing an unauthenticated proxy on the network.
+
+    *cache_dir* is resolved to an absolute path before opening the cache
+    so the daemon's on-disk state lands somewhere predictable when run
+    under a supervisor (systemd, supervisord, docker) where the CWD
+    isn't where the operator expects.  The resolved path is logged at
+    startup.
     """
     if host not in ("127.0.0.1", "localhost", "::1") and not allow_remote:
         raise SystemExit(
@@ -218,36 +225,65 @@ def run(
             "--allow-remote once authentication is wired up."
         )
 
-    backend = LocalBackend(cache=True, cache_dir=cache_dir)
+    if not str(cache_dir).strip():
+        raise SystemExit(
+            "agentopt serve: --cache-dir cannot be empty.  Pass a path."
+        )
+    resolved_cache_dir = Path(cache_dir).expanduser().resolve()
+
+    backend = LocalBackend(cache=True, cache_dir=resolved_cache_dir)
     backend.start()
     try:
         _warmup_ca(backend)
         app = make_app(backend)
-        logger.info("agentopt serve listening on http://%s:%d", host, port)
+        logger.info(
+            "agentopt serve listening on http://%s:%d (cache dir: %s)",
+            host, port, resolved_cache_dir,
+        )
         web.run_app(app, host=host, port=port, print=None, handle_signals=True)
     finally:
         backend.stop()
 
 
-def cli(argv: Optional[List[str]] = None) -> None:
-    """argparse entrypoint for the ``agentopt serve`` subcommand."""
-    parser = argparse.ArgumentParser(prog="agentopt serve")
-    parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=9000)
-    parser.add_argument("--cache-dir", default=".agentopt_cache")
-    parser.add_argument(
+def register_serve_subparser(
+    subparsers: "argparse._SubParsersAction",
+) -> argparse.ArgumentParser:
+    """Register ``agentopt serve`` on the top-level CLI parser.
+
+    Returns the subparser (for callers that want to introspect it).
+    Sets ``args.func = _serve_main`` so :func:`agentopt.cli.main` can
+    dispatch generically via ``args.func(args)``.
+    """
+    p = subparsers.add_parser(
+        "serve",
+        help="Run the long-lived gateway daemon.",
+        description="Run the agentopt gateway daemon (localhost-only).",
+    )
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=9000)
+    p.add_argument(
+        "--cache-dir",
+        default=".agentopt_cache",
+        help="Directory for the response cache (cache.db). Resolved to an "
+             "absolute path relative to the daemon's CWD at startup; the "
+             "resolved path is logged. Default: ./.agentopt_cache",
+    )
+    p.add_argument(
         "--allow-remote",
         action="store_true",
         help="(reserved) bind a non-localhost host. Requires auth which is not yet shipped.",
     )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    args = parser.parse_args(argv)
+    p.add_argument("-v", "--verbose", action="store_true")
+    p.set_defaults(func=_serve_main)
+    return p
 
+
+def _serve_main(args: argparse.Namespace) -> None:
+    """Dispatched by :func:`agentopt.cli.main` after argument parsing."""
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(
         level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
     )
-
     run(
         host=args.host,
         port=args.port,

--- a/src/agentopt/proxy/interceptor.py
+++ b/src/agentopt/proxy/interceptor.py
@@ -2,21 +2,26 @@
 
 The active tracking session lives in a ``ContextVar`` set by
 ``LLMTracker.track()``.  When httpx is about to send a POST whose URL
-matches a known LLM endpoint, we cache-look-up first and short-circuit on
-hit, otherwise we forward the call to the real upstream, then record the
-result and (for 200s) populate the cache.
+matches a known LLM endpoint, the patched ``send`` hands the request off
+to the session's :class:`CallHandler` to do the actual work.
 
-No localhost round-trip — the in-process path doesn't need a proxy
-listener.  Only subprocess agents do; they go through the mitmproxy-based
-``SessionMaster`` (see ``mitm_runner.py``).
+Two handlers ship with the proxy:
 
-The httpx wrapper is a process-wide monkey-patch installed once by
-``LLMTracker.start()``; the ContextVar makes it safe under concurrent
-``track()`` blocks in different async tasks or threads.
+* :class:`LocalHandler` — the original in-process behaviour (cache
+  lookup, forward to upstream, record).  Used by :class:`LocalBackend`.
+* :class:`RemoteHandler` (see :mod:`._remote_backend`) — forwards the
+  request through a long-lived daemon's per-session proxy port; the
+  daemon performs cache and recording.  Used by ``RemoteBackend``.
+
+The handler seam is the smallest possible split: the patched
+``send`` is a dispatcher; everything else (cache, forward, record)
+lives in the handler.  Both modes share the ContextVar activation, the
+fast-path check (``_is_llm_request``), and the install/uninstall plumbing.
 """
 
 from __future__ import annotations
 
+import abc
 import json
 import time
 from contextvars import ContextVar
@@ -29,33 +34,6 @@ from .cache import CacheEntry, ResponseCache, _make_cache_key
 from .recording import Recorder
 from .session import SessionInfo
 from .usage import is_streaming_request
-
-
-# ---------------------------------------------------------------------------
-# Active-session context — populated by ``LLMTracker.track()``.
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ActiveSession:
-    """Per-track() bundle: what the wrapper needs to record a call.
-
-    ``path_patterns`` is a snapshot of the owning tracker's
-    :class:`ProviderRegistry` patterns at ``track()`` entry — consulting
-    it (rather than a process-global set) keeps registrations on one
-    tracker from leaking into other tracker instances.
-    """
-
-    session: SessionInfo
-    recorder: Recorder
-    cache: Optional[ResponseCache]
-    port: int  # ``SessionMaster`` port — for ``get_current_session_proxy``
-    path_patterns: FrozenSet[str]
-
-
-_active_session_var: ContextVar[Optional[ActiveSession]] = ContextVar(
-    "agentopt_active_session", default=None,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +50,7 @@ def _is_llm_request(request: httpx.Request, patterns: FrozenSet[str]) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Recording — shared by sync and async paths
+# Body / response helpers (shared by all handlers)
 # ---------------------------------------------------------------------------
 
 
@@ -99,59 +77,204 @@ def _make_cached_response(request: httpx.Request, entry: CacheEntry,) -> httpx.R
     )
 
 
-def _record_after_response(
-    active: ActiveSession,
-    request: httpx.Request,
-    response: Optional[httpx.Response],
-    error: Optional[str],
-    latency: float,
-    cached: bool,
-) -> None:
-    """Convert a completed (or failed) httpx exchange into a CallRecord."""
-    json_body = _decode_json_body(request.content)
-    request_url = str(request.url)
-    is_streaming = is_streaming_request(json_body, request_url)
+# ---------------------------------------------------------------------------
+# CallHandler — the work the patched send dispatches to.
+# ---------------------------------------------------------------------------
 
-    if response is None:
-        active.recorder.record(
-            active.session,
+
+class CallHandler(abc.ABC):
+    """Per-session strategy for handling an intercepted LLM HTTP call."""
+
+    @abc.abstractmethod
+    def handle_sync(
+        self,
+        client: httpx.Client,
+        request: httpx.Request,
+        *,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Synchronously process *request*; return the response to the caller."""
+
+    @abc.abstractmethod
+    async def handle_async(
+        self,
+        client: httpx.AsyncClient,
+        request: httpx.Request,
+        *,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Asynchronously process *request*; return the response."""
+
+
+class LocalHandler(CallHandler):
+    """In-process handler: cache lookup, forward to upstream, record.
+
+    This is the body of the original ``_patched_sync_send`` /
+    ``_patched_async_send`` extracted into a class so that a remote-mode
+    handler can plug into the same seam.
+    """
+
+    def __init__(
+        self, session: SessionInfo, recorder: Recorder, cache: Optional[ResponseCache],
+    ) -> None:
+        self._session = session
+        self._recorder = recorder
+        self._cache = cache
+
+    # -- sync ---------------------------------------------------------
+
+    def handle_sync(
+        self,
+        client: httpx.Client,
+        request: httpx.Request,
+        *,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        json_body = _decode_json_body(request.content)
+        # Cache lookup
+        if self._cache is not None and json_body:
+            entry = self._cache.get(_make_cache_key(json_body, str(request.url.path)))
+            if entry is not None:
+                resp = _make_cached_response(request, entry)
+                self._record(
+                    request, resp, None, entry.latency_seconds, cached=True,
+                )
+                return resp
+
+        assert _original_sync_send is not None  # set by install_redirect
+        t0 = time.monotonic()
+        try:
+            response = _original_sync_send(client, request, stream=stream, **kwargs)
+        except Exception as exc:
+            latency = time.monotonic() - t0
+            self._record(request, None, str(exc), latency, cached=False)
+            raise
+        latency = time.monotonic() - t0
+        self._record(request, response, None, latency, cached=False)
+        return response
+
+    # -- async --------------------------------------------------------
+
+    async def handle_async(
+        self,
+        client: httpx.AsyncClient,
+        request: httpx.Request,
+        *,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        json_body = _decode_json_body(request.content)
+        if self._cache is not None and json_body:
+            entry = self._cache.get(_make_cache_key(json_body, str(request.url.path)))
+            if entry is not None:
+                resp = _make_cached_response(request, entry)
+                self._record(
+                    request, resp, None, entry.latency_seconds, cached=True,
+                )
+                return resp
+
+        assert _original_async_send is not None
+        t0 = time.monotonic()
+        try:
+            response = await _original_async_send(
+                client, request, stream=stream, **kwargs,
+            )
+        except Exception as exc:
+            latency = time.monotonic() - t0
+            self._record(request, None, str(exc), latency, cached=False)
+            raise
+        latency = time.monotonic() - t0
+        self._record(request, response, None, latency, cached=False)
+        return response
+
+    # -- recording (shared by sync + async) --------------------------
+
+    def _record(
+        self,
+        request: httpx.Request,
+        response: Optional[httpx.Response],
+        error: Optional[str],
+        latency: float,
+        *,
+        cached: bool,
+    ) -> None:
+        """Convert a completed (or failed) httpx exchange into a CallRecord."""
+        json_body = _decode_json_body(request.content)
+        request_url = str(request.url)
+        is_streaming = is_streaming_request(json_body, request_url)
+
+        if response is None:
+            self._recorder.record(
+                self._session,
+                json_body,
+                None,
+                request_url,
+                latency,
+                cached=False,
+                is_streaming=is_streaming,
+                status_code=0,
+                error=error or "upstream error",
+            )
+            return
+
+        status = response.status_code
+        body_bytes = response.content  # forces buffering for streamed bodies
+        record_error = None if status == 200 else f"HTTP {status}"
+
+        self._recorder.record(
+            self._session,
             json_body,
-            None,
+            body_bytes,
             request_url,
             latency,
-            cached=False,
+            cached=cached,
             is_streaming=is_streaming,
-            status_code=0,
-            error=error or "upstream error",
+            status_code=status,
+            error=record_error,
         )
-        return
 
-    status = response.status_code
-    body_bytes = response.content  # forces buffering for streamed bodies
-    record_error = None if status == 200 else f"HTTP {status}"
+        # Cache successful 200s on the miss path only.
+        if not cached and status == 200 and self._cache is not None and json_body:
+            self._cache.put(
+                _make_cache_key(json_body, str(request.url.path)),
+                CacheEntry(
+                    response_bytes=body_bytes,
+                    response_headers=dict(response.headers),
+                    latency_seconds=latency,
+                ),
+            )
 
-    active.recorder.record(
-        active.session,
-        json_body,
-        body_bytes,
-        request_url,
-        latency,
-        cached=cached,
-        is_streaming=is_streaming,
-        status_code=status,
-        error=record_error,
-    )
 
-    # Cache successful 200s on the miss path only.
-    if not cached and status == 200 and active.cache is not None and json_body:
-        active.cache.put(
-            _make_cache_key(json_body, str(request.url.path)),
-            CacheEntry(
-                response_bytes=body_bytes,
-                response_headers=dict(response.headers),
-                latency_seconds=latency,
-            ),
-        )
+# ---------------------------------------------------------------------------
+# Active-session context — populated by ``LLMTracker.track()``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActiveSession:
+    """Per-track() bundle: what the patched ``send`` needs to dispatch a call.
+
+    ``path_patterns`` is a snapshot of the owning backend's
+    :class:`ProviderRegistry` patterns at ``track()`` entry — consulting
+    it (rather than a process-global set) keeps registrations on one
+    tracker from leaking into other tracker instances.
+
+    ``handler`` is the per-session strategy (cache+forward+record locally,
+    or forward through a daemon).  See :class:`CallHandler`.
+    """
+
+    session: SessionInfo
+    port: int  # session's proxy port (local SessionMaster or daemon-allocated)
+    path_patterns: FrozenSet[str]
+    handler: CallHandler
+
+
+_active_session_var: ContextVar[Optional[ActiveSession]] = ContextVar(
+    "agentopt_active_session", default=None,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -182,31 +305,7 @@ def install_redirect() -> None:
         active = _active_session_var.get()
         if active is None or not _is_llm_request(request, active.path_patterns):
             return _original_sync_send(self, request, stream=stream, **kwargs)  # type: ignore[misc]
-
-        json_body = _decode_json_body(request.content)
-        # Cache lookup
-        if active.cache is not None and json_body:
-            entry = active.cache.get(_make_cache_key(json_body, str(request.url.path)))
-            if entry is not None:
-                resp = _make_cached_response(request, entry)
-                _record_after_response(
-                    active, request, resp, None, entry.latency_seconds, cached=True,
-                )
-                return resp
-
-        # Forward to real upstream
-        t0 = time.monotonic()
-        try:
-            response = _original_sync_send(self, request, stream=stream, **kwargs)  # type: ignore[misc]
-        except Exception as exc:
-            latency = time.monotonic() - t0
-            _record_after_response(
-                active, request, None, str(exc), latency, cached=False
-            )
-            raise
-        latency = time.monotonic() - t0
-        _record_after_response(active, request, response, None, latency, cached=False)
-        return response
+        return active.handler.handle_sync(self, request, stream=stream, **kwargs)
 
     async def _patched_async_send(
         self: Any, request: httpx.Request, *, stream: bool = False, **kwargs: Any,
@@ -214,33 +313,41 @@ def install_redirect() -> None:
         active = _active_session_var.get()
         if active is None or not _is_llm_request(request, active.path_patterns):
             return await _original_async_send(self, request, stream=stream, **kwargs)  # type: ignore[misc]
-
-        json_body = _decode_json_body(request.content)
-        if active.cache is not None and json_body:
-            entry = active.cache.get(_make_cache_key(json_body, str(request.url.path)))
-            if entry is not None:
-                resp = _make_cached_response(request, entry)
-                _record_after_response(
-                    active, request, resp, None, entry.latency_seconds, cached=True,
-                )
-                return resp
-
-        t0 = time.monotonic()
-        try:
-            response = await _original_async_send(self, request, stream=stream, **kwargs)  # type: ignore[misc]
-        except Exception as exc:
-            latency = time.monotonic() - t0
-            _record_after_response(
-                active, request, None, str(exc), latency, cached=False
-            )
-            raise
-        latency = time.monotonic() - t0
-        _record_after_response(active, request, response, None, latency, cached=False)
-        return response
+        return await active.handler.handle_async(self, request, stream=stream, **kwargs)
 
     httpx.Client.send = _patched_sync_send  # type: ignore[assignment]
     httpx.AsyncClient.send = _patched_async_send  # type: ignore[assignment]
     _installed = True
+
+
+def forward_sync(
+    client: httpx.Client,
+    request: httpx.Request,
+    *,
+    stream: bool = False,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Forward a request via the saved-original ``httpx.Client.send``.
+
+    Lets a handler in a *different* module (e.g. ``RemoteHandler``)
+    bypass the patch without importing the private module global at
+    import time (the value is ``None`` until :func:`install_redirect`
+    runs).
+    """
+    assert _original_sync_send is not None, "install_redirect() not called"
+    return _original_sync_send(client, request, stream=stream, **kwargs)
+
+
+async def forward_async(
+    client: httpx.AsyncClient,
+    request: httpx.Request,
+    *,
+    stream: bool = False,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Async counterpart of :func:`forward_sync`."""
+    assert _original_async_send is not None, "install_redirect() not called"
+    return await _original_async_send(client, request, stream=stream, **kwargs)
 
 
 def uninstall_redirect() -> None:

--- a/src/agentopt/proxy/tracker.py
+++ b/src/agentopt/proxy/tracker.py
@@ -23,10 +23,10 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from ._backend import (
     _MITMPROXY_CA_CERT,
     _MITMPROXY_CONFDIR,
-    LocalBackend,
     _Backend,
     _ensure_ca_bundle,
 )
+from ._local_backend import LocalBackend
 from .models import CallRecord
 from .session import SessionInfo
 

--- a/src/agentopt/proxy/tracker.py
+++ b/src/agentopt/proxy/tracker.py
@@ -112,8 +112,29 @@ class LLMTracker:
         self._backend.start()
 
     def stop(self) -> None:
-        """Tear down all live sessions, restore httpx, flush cache."""
+        """Tear down all live sessions, restore httpx, flush cache.
+
+        Record queries remain valid after ``stop()``; call :meth:`close`
+        for full teardown (releases the remote backend's HTTP client).
+        """
         self._backend.stop()
+
+    def close(self) -> None:
+        """Final teardown.  Idempotent; safe to call after ``stop``.
+
+        Releases every resource the backend holds.  For ``RemoteBackend``
+        this drops the long-lived control-plane HTTP client; for
+        ``LocalBackend`` this is equivalent to ``stop`` when the tracker
+        is still active and a no-op otherwise.
+        """
+        self._backend.close()
+
+    # Context-manager sugar: ``with LLMTracker() as tracker:`` auto-closes.
+    def __enter__(self) -> "LLMTracker":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
 
     # ------------------------------------------------------------------
     # Session tracking

--- a/src/agentopt/proxy/tracker.py
+++ b/src/agentopt/proxy/tracker.py
@@ -1,98 +1,62 @@
-"""LLMTracker — proxy-based LLM call tracking and session management.
+"""LLMTracker — public proxy-based LLM call tracker.
 
-Two interception paths, separately:
+Thin delegator to a :class:`_Backend`.  Two backends ship with the
+package:
 
-* **In-process agents** — :mod:`agentopt.proxy.interceptor` patches
-  ``httpx`` so calls inside a ``track()`` block are recorded directly
-  (cache-then-forward).  No localhost listener.
-* **Subprocess agents** — each ``track()`` eagerly spins up a
-  :class:`SessionMaster` (one mitmproxy ``DumpMaster`` on a dedicated
-  ephemeral port).  Subprocesses inherit ``HTTPS_PROXY`` and the merged
-  CA bundle via :meth:`get_session_env`.
+* :class:`LocalBackend` — runs the mitmproxy ``SessionMaster`` in the
+  current Python process (default).
+* :class:`RemoteBackend` — talks to a long-lived ``agentopt serve``
+  daemon over HTTP.  Selected when the ``AGENTOPT_GATEWAY_URL`` env
+  var is set.
 
-The two paths share the same recording (:mod:`recording.Recorder`),
-cache (:mod:`cache.ResponseCache`), and provider registry
-(:mod:`providers.ProviderRegistry`), so a record is a record regardless
-of how the call arrived.
+The tracker's public surface is unchanged; switching modes is a
+deployment concern, not an API choice.
 """
 
 from __future__ import annotations
 
-import logging
 import os
-import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-import certifi
-
-from .cache import ResponseCache
-from .interceptor import (
-    ActiveSession,
-    _active_session_var,
-    install_redirect,
-    uninstall_redirect,
+from ._backend import (
+    _MITMPROXY_CA_CERT,
+    _MITMPROXY_CONFDIR,
+    LocalBackend,
+    _Backend,
+    _ensure_ca_bundle,
 )
-from .mitm_runner import SessionMaster
 from .models import CallRecord
-from .providers import ProviderRegistry
-from .recording import Recorder
-from .session import SessionInfo, SessionManager
+from .session import SessionInfo
 
-logger = logging.getLogger(__name__)
-
-
-# mitmproxy's confdir defaults to ~/.mitmproxy.  We don't override it —
-# users may already have a mitmproxy CA installed in their browser/system
-# keychain, and reusing it avoids re-prompting them.
-_MITMPROXY_CONFDIR = Path(os.path.expanduser("~/.mitmproxy"))
-_MITMPROXY_CA_CERT = _MITMPROXY_CONFDIR / "mitmproxy-ca-cert.pem"
-# Where we write the merged bundle (mitmproxy CA + system CAs from certifi).
-# Subprocesses set SSL_CERT_FILE to this so they can verify *both*
-# mitmproxy-impersonated LLM hosts AND real (passthrough) hosts.
-_AGENTOPT_BUNDLE = _MITMPROXY_CONFDIR / "agentopt-bundle.pem"
-
-
-def _ensure_ca_bundle() -> str:
-    """Return path to a CA bundle = mitmproxy CA + certifi system CAs.
-
-    Subprocesses need this — setting ``SSL_CERT_FILE`` to mitmproxy's CA
-    alone would break verification for any host the proxy *doesn't* MITM
-    (passthrough hosts that the subprocess talks to directly).
-
-    Idempotent: if the bundle is already up to date with mitmproxy's CA,
-    no work is done.
-    """
-    if not _MITMPROXY_CA_CERT.exists():
-        raise RuntimeError(
-            f"mitmproxy CA cert not found at {_MITMPROXY_CA_CERT}. "
-            "Has any SessionMaster started yet?"
-        )
-
-    ca_mtime = _MITMPROXY_CA_CERT.stat().st_mtime
-    if _AGENTOPT_BUNDLE.exists() and _AGENTOPT_BUNDLE.stat().st_mtime >= ca_mtime:
-        return str(_AGENTOPT_BUNDLE)
-
-    with open(certifi.where(), "rb") as f:
-        system_pem = f.read()
-    with open(_MITMPROXY_CA_CERT, "rb") as f:
-        mitm_pem = f.read()
-
-    # Append rather than prepend so existing trust roots take precedence.
-    _AGENTOPT_BUNDLE.write_bytes(system_pem + b"\n" + mitm_pem)
-    return str(_AGENTOPT_BUNDLE)
+__all__ = [
+    "LLMTracker",
+    # Re-exports so ``agentopt/__init__.py`` and any external callers can
+    # continue to import these helpers from ``agentopt.proxy.tracker``.
+    "_MITMPROXY_CA_CERT",
+    "_MITMPROXY_CONFDIR",
+    "_ensure_ca_bundle",
+]
 
 
 class LLMTracker:
-    """Tracks LLM API calls via in-process httpx patching + per-session mitmproxy.
+    """Tracks LLM API calls via a pluggable backend.
 
-    Every :meth:`track` block:
+    Selection rule (in ``__init__``):
 
-    * Records in-process httpx calls directly (cache → forward → record).
-    * Eagerly spins up a per-session ``SessionMaster`` so
-      :meth:`get_session_env` can hand subprocesses a working HTTPS_PROXY
-      pair without an extra round-trip.
+    * ``AGENTOPT_GATEWAY_URL`` set → :class:`RemoteBackend` (talks to a
+      running ``agentopt serve`` daemon).
+    * Otherwise → :class:`LocalBackend` (today's in-process proxy).
+
+    The public surface is identical in both modes — the env var is the
+    entire deployment switch::
+
+        # Dev (default)
+        python my_script.py
+
+        # Production
+        AGENTOPT_GATEWAY_URL=http://gw.team.local:9000 python my_script.py
 
     Usage::
 
@@ -109,55 +73,47 @@ class LLMTracker:
     """
 
     _DEFAULT_CACHE_DIR = ".agentopt_cache"
+    _GATEWAY_URL_ENV = "AGENTOPT_GATEWAY_URL"
 
     def __init__(
         self,
         cache: bool = True,
         cache_dir: Optional[Union[str, Path]] = _DEFAULT_CACHE_DIR,
     ) -> None:
-        self._records: List[CallRecord] = []
-        self._lock = threading.Lock()
-        self._active = False
-        self._response_cache = ResponseCache(cache_dir=cache_dir) if cache else None
-        self._session_manager = SessionManager()
-        self._registry = ProviderRegistry()
-        self._recorder = Recorder(self._session_manager)
-        # session_id -> SessionMaster
-        self._masters: Dict[str, SessionMaster] = {}
-        self._masters_lock = threading.Lock()
+        url = os.environ.get(self._GATEWAY_URL_ENV)
+        if url:
+            # Imported lazily so the local-mode-only install path doesn't
+            # have to evaluate the remote backend module.
+            from ._remote_backend import RemoteBackend
+
+            self._backend: _Backend = RemoteBackend(gateway_url=url)
+        else:
+            self._backend = LocalBackend(cache=cache, cache_dir=cache_dir)
+
+    # ------------------------------------------------------------------
+    # Backend access (tests / advanced callers)
+    # ------------------------------------------------------------------
+
+    @property
+    def _registry(self):
+        """Local-mode provider registry.
+
+        Exposed for tests that introspect the registry directly.  Raises
+        ``AttributeError`` in remote mode (registry lives on the daemon).
+        """
+        return self._backend._registry  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Install the httpx redirect.  Subprocess masters spin up per-track()."""
-        if self._active:
-            return
-        install_redirect()
-        self._active = True
+        """Install the httpx redirect and prepare the backend for ``track()``."""
+        self._backend.start()
 
     def stop(self) -> None:
-        """Tear down all live SessionMasters, restore httpx, flush cache."""
-        if not self._active:
-            return
-        uninstall_redirect()
-        # Stop any masters that survived (track() should have closed them,
-        # but in test/error paths they may linger).
-        with self._masters_lock:
-            masters = list(self._masters.values())
-            self._masters.clear()
-        for m in masters:
-            try:
-                m.stop()
-            except Exception:
-                logger.debug("ignored exception in SessionMaster.stop", exc_info=True)
-        self._session_manager.force_end_all()
-        with self._lock:
-            self._records.extend(self._session_manager.get_all_records())
-        if self._response_cache is not None:
-            self._response_cache.close()
-        self._active = False
+        """Tear down all live sessions, restore httpx, flush cache."""
+        self._backend.stop()
 
     # ------------------------------------------------------------------
     # Session tracking
@@ -166,59 +122,12 @@ class LLMTracker:
     @contextmanager
     def track(
         self, data_id: str, combo_id: str, agent_id: Optional[str] = None,
-    ):
-        """Create a tracking session with its own mitmproxy port.
-
-        Sets the ``_active_session_var`` ContextVar so the in-process
-        httpx patch records calls into this session.  Eagerly starts a
-        ``SessionMaster`` so subprocesses can use ``get_session_env``
-        without further setup.
-        """
-        assert self._active, "call tracker.start() first"
-
-        session = self._session_manager.create_session(
+    ) -> Iterator[SessionInfo]:
+        """Open a tracking session.  See :meth:`_Backend.track`."""
+        with self._backend.track(
             data_id=data_id, combo_id=combo_id, agent_id=agent_id,
-        )
-        master = SessionMaster(
-            session=session,
-            registry=self._registry,
-            recorder=self._recorder,
-            cache=self._response_cache,
-        )
-        try:
-            port = master.start()
-            with self._masters_lock:
-                self._masters[session.session_id] = master
-        except Exception:
-            try:
-                master.stop()
-            except Exception:
-                logger.exception(
-                    "Failed to stop SessionMaster after startup failure for session %s",
-                    session.session_id,
-                )
-            finally:
-                self._session_manager.end_session(session.session_id)
-            raise
-
-        active = ActiveSession(
-            session=session,
-            recorder=self._recorder,
-            cache=self._response_cache,
-            port=port,
-            path_patterns=self._registry.path_patterns,
-        )
-        token = _active_session_var.set(active)
-
-        try:
+        ) as session:
             yield session
-        finally:
-            _active_session_var.reset(token)
-            with self._masters_lock:
-                m = self._masters.pop(session.session_id, None)
-            if m is not None:
-                m.stop()
-            self._session_manager.end_session(session.session_id)
 
     # ------------------------------------------------------------------
     # Subprocess helpers
@@ -233,19 +142,7 @@ class LLMTracker:
                 env = {**os.environ, **tracker.get_session_env(session)}
                 subprocess.run(["tb", "run", ...], env=env)
         """
-        with self._masters_lock:
-            master = self._masters.get(session.session_id)
-        assert master is not None, (
-            f"no SessionMaster for {session.session_id}; "
-            "is the session inside its track() scope?"
-        )
-        bundle = _ensure_ca_bundle()
-        return {
-            "HTTPS_PROXY": f"http://127.0.0.1:{master.port}",
-            "SSL_CERT_FILE": bundle,
-            "REQUESTS_CA_BUNDLE": bundle,
-            "NODE_EXTRA_CA_CERTS": bundle,
-        }
+        return self._backend.get_session_env(session)
 
     # ------------------------------------------------------------------
     # Provider registry
@@ -254,16 +151,8 @@ class LLMTracker:
     def register_provider(
         self, name: str, base_url: str, path_patterns: tuple,
     ) -> None:
-        """Add or replace a provider.
-
-        The shared ``ProviderRegistry`` is updated for both interception
-        paths: the subprocess addon sees the new intercept hostname
-        immediately via the shared reference, and the in-process httpx
-        patch picks up the new path patterns at the next ``track()``
-        entry (which snapshots ``registry.path_patterns`` onto the
-        ``ActiveSession``).
-        """
-        self._registry.register(name, base_url, path_patterns)
+        """Add or replace an LLM provider."""
+        self._backend.register_provider(name, base_url, path_patterns)
 
     # ------------------------------------------------------------------
     # Cache management
@@ -271,24 +160,15 @@ class LLMTracker:
 
     def flush_cache(self) -> None:
         """Flush dirty cache entries to disk immediately."""
-        if self._response_cache is not None:
-            self._response_cache.flush()
+        self._backend.flush_cache()
 
     def clear_cache(self) -> None:
         """Clear all cached responses and database rows."""
-        if self._response_cache is not None:
-            self._response_cache.clear()
+        self._backend.clear_cache()
 
     # ------------------------------------------------------------------
     # Record queries
     # ------------------------------------------------------------------
-
-    def _all_records(self) -> List[CallRecord]:
-        """Gather records from both the local archive and live sessions."""
-        with self._lock:
-            records = list(self._records)
-        records.extend(self._session_manager.get_all_records())
-        return records
 
     def get_records(
         self,
@@ -297,16 +177,9 @@ class LLMTracker:
         agent_id: Optional[str] = None,
     ) -> List[CallRecord]:
         """Return ``CallRecord`` list, filtered by any combination of IDs."""
-        result = []
-        for r in self._all_records():
-            if data_id is not None and r.data_id != data_id:
-                continue
-            if combo_id is not None and r.combo_id != combo_id:
-                continue
-            if agent_id is not None and r.agent_id != agent_id:
-                continue
-            result.append(r)
-        return result
+        return self._backend.get_records(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
+        )
 
     def get_usage(
         self,
@@ -315,16 +188,9 @@ class LLMTracker:
         agent_id: Optional[str] = None,
     ) -> Dict[str, Tuple[int, int]]:
         """Return aggregated ``{model: (input_tokens, output_tokens)}``."""
-        records = self.get_records(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        return self._backend.get_usage(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
         )
-        totals: Dict[str, List[int]] = {}
-        for r in records:
-            if r.model not in totals:
-                totals[r.model] = [0, 0]
-            totals[r.model][0] += r.prompt_tokens
-            totals[r.model][1] += r.completion_tokens
-        return {k: (v[0], v[1]) for k, v in totals.items()}
 
     def get_cached_latency(
         self,
@@ -333,12 +199,10 @@ class LLMTracker:
         agent_id: Optional[str] = None,
     ) -> float:
         """Return total latency (seconds) from cached responses."""
-        records = self.get_records(
-            data_id=data_id, combo_id=combo_id, agent_id=agent_id
+        return self._backend.get_cached_latency(
+            data_id=data_id, combo_id=combo_id, agent_id=agent_id,
         )
-        return sum(r.latency_seconds for r in records if r.cached)
 
     def clear(self) -> None:
         """Clear all locally archived records."""
-        with self._lock:
-            self._records.clear()
+        self._backend.clear()

--- a/tests/test_daemon_e2e.py
+++ b/tests/test_daemon_e2e.py
@@ -265,6 +265,38 @@ def test_remote_get_records_works_after_stop(daemon, mock_upstream, monkeypatch)
     assert records[0].model == "gpt-4o-mini"
 
 
+def test_remote_close_releases_control_plane_client(daemon, monkeypatch):
+    """``close()`` actually closes the long-lived httpx client.
+
+    Without this, the client lingers until ``__del__`` and httpx emits
+    an "Unclosed client" warning at GC time.
+    """
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    tracker = LLMTracker()
+    tracker.start()
+    tracker.stop()
+    # _http stays open across stop() so post-stop record queries work.
+    assert not tracker._backend._http.is_closed  # type: ignore[attr-defined]
+
+    tracker.close()
+    assert tracker._backend._http.is_closed  # type: ignore[attr-defined]
+
+    # Idempotent — calling close() again must not raise.
+    tracker.close()
+
+
+def test_remote_context_manager_closes(daemon, monkeypatch):
+    """``with LLMTracker() as tracker:`` releases the control-plane client."""
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    with LLMTracker() as tracker:
+        tracker.start()
+        with tracker.track(data_id="dp", combo_id="c"):
+            pass
+        tracker.stop()
+        backend = tracker._backend
+    assert backend._http.is_closed  # type: ignore[attr-defined]
+
+
 def test_daemon_rejects_empty_cache_dir():
     """``run(cache_dir='')`` fails fast — silently allowing it would land
     the cache somewhere unpredictable under a supervisor."""

--- a/tests/test_daemon_e2e.py
+++ b/tests/test_daemon_e2e.py
@@ -143,16 +143,24 @@ def test_remote_in_process_call_is_recorded(daemon, mock_upstream, monkeypatch):
 
 def test_remote_get_session_env_points_at_daemon(daemon, monkeypatch):
     """``get_session_env`` returns the daemon's per-session port + bundle."""
+    from urllib.parse import urlparse
+
     monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    daemon_url = urlparse(daemon)
     tracker = LLMTracker()
     tracker.start()
     try:
         with tracker.track(data_id="dp", combo_id="c") as session:
             env = tracker.get_session_env(session)
-            assert "HTTPS_PROXY" in env
-            assert env["HTTPS_PROXY"].startswith("http://127.0.0.1:")
+
+            proxy = urlparse(env["HTTPS_PROXY"])
+            assert proxy.scheme == "http"
+            assert proxy.hostname == daemon_url.hostname == "127.0.0.1"
+            assert proxy.path in ("", "/")  # no extra path components
             # Per-session port is distinct from the control-plane port.
-            assert env["HTTPS_PROXY"] != daemon
+            assert proxy.port is not None
+            assert proxy.port != daemon_url.port
+
             assert env["SSL_CERT_FILE"].endswith("ca-bundle.pem")
             assert env["REQUESTS_CA_BUNDLE"] == env["SSL_CERT_FILE"]
             assert env["NODE_EXTRA_CA_CERTS"] == env["SSL_CERT_FILE"]
@@ -171,6 +179,63 @@ def test_remote_no_op_endpoints(daemon, monkeypatch):
         assert tracker.get_cached_latency(combo_id="never") == 0.0
         tracker.flush_cache()
         tracker.clear_cache()
+    finally:
+        tracker.stop()
+
+
+def test_remote_handler_lazy_async_client(daemon, monkeypatch):
+    """``RemoteHandler.close()`` is safe when ``handle_async`` was never called.
+
+    Regression: prior to the lazy-creation fix, an ``AsyncClient`` was
+    eagerly constructed in ``__init__``; ``close()`` then called the
+    nonexistent ``AsyncClient.close()`` (only ``aclose()`` exists),
+    raising ``AttributeError`` that was silently swallowed and leaking
+    the connection pool every time ``track()`` exited.
+    """
+    import certifi
+
+    from agentopt.proxy._remote_backend import RemoteHandler
+
+    h = RemoteHandler(
+        proxy_url="http://127.0.0.1:1",  # arbitrary; never sent to
+        ca_bundle_path=certifi.where(),  # any valid PEM; never verified
+    )
+    assert h._async_client is None
+    h.close()  # must not raise
+    assert h._async_client is None  # still uncreated — no leak
+
+
+def test_remote_async_in_process_call_is_recorded(daemon, mock_upstream, monkeypatch):
+    """Async (``httpx.AsyncClient``) LLM call records cleanly through the daemon.
+
+    Also exercises the async-cleanup path in ``RemoteHandler.close()`` —
+    the prior implementation silently failed here, leaving the
+    ``AsyncClient``'s connection pool open across runs.
+    """
+    import asyncio
+
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    tracker = LLMTracker()
+    tracker.start()
+    try:
+        async def make_call():
+            async with httpx.AsyncClient(base_url=mock_upstream.base_url) as client:
+                resp = await client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+                assert resp.status_code == 200
+
+        with tracker.track(data_id="dp_async", combo_id="c_async"):
+            asyncio.run(make_call())
+
+        records = tracker.get_records(combo_id="c_async")
+        assert len(records) == 1
+        assert records[0].model == "gpt-4o-mini"
+        assert records[0].status_code == 200
     finally:
         tracker.stop()
 
@@ -198,6 +263,15 @@ def test_remote_get_records_works_after_stop(daemon, mock_upstream, monkeypatch)
     records = tracker.get_records(combo_id="c")
     assert len(records) == 1
     assert records[0].model == "gpt-4o-mini"
+
+
+def test_daemon_rejects_empty_cache_dir():
+    """``run(cache_dir='')`` fails fast — silently allowing it would land
+    the cache somewhere unpredictable under a supervisor."""
+    from agentopt.proxy.daemon import run
+
+    with pytest.raises(SystemExit, match="cache-dir cannot be empty"):
+        run(host="127.0.0.1", port=0, cache_dir="")
 
 
 def test_remote_gateway_unreachable_fails_fast(monkeypatch):

--- a/tests/test_daemon_e2e.py
+++ b/tests/test_daemon_e2e.py
@@ -1,0 +1,209 @@
+"""End-to-end test for the ``agentopt serve`` daemon + ``RemoteBackend``.
+
+Spawns the daemon as a subprocess on an ephemeral port, points
+``LLMTracker`` at it via ``AGENTOPT_GATEWAY_URL``, and verifies that an
+in-process ``httpx`` call produces the same kind of ``CallRecord`` the
+local backend would have produced for the same traffic.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+from agentopt.proxy import LLMTracker
+
+
+# ---------------------------------------------------------------------------
+# Daemon subprocess fixture
+# ---------------------------------------------------------------------------
+
+
+def _pick_free_port() -> int:
+    """Return a free TCP port on 127.0.0.1.
+
+    Race-safe enough for tests: the kernel's ephemeral allocation tends
+    not to reuse the same port within a short window.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(url: str, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(f"{url}/health", timeout=2.0)
+            if r.status_code == 200:
+                return
+        except httpx.HTTPError as exc:
+            last_err = exc
+        time.sleep(0.25)
+    raise RuntimeError(
+        f"agentopt serve at {url} did not become ready within {timeout}s "
+        f"(last error: {last_err!r})"
+    )
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    """Spawn ``agentopt serve`` in a subprocess; yield its base URL."""
+    port = _pick_free_port()
+    cache_dir = tmp_path / "agentopt_cache"
+    log_path = tmp_path / "daemon.log"
+
+    log_handle = open(log_path, "wb")
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "agentopt.cli",
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--cache-dir",
+            str(cache_dir),
+        ],
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+    url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_health(url)
+        yield url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        log_handle.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_health(daemon):
+    """Sanity: /health returns 200 once the fixture has started."""
+    r = httpx.get(f"{daemon}/health", timeout=5.0)
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+def test_remote_in_process_call_is_recorded(daemon, mock_upstream, monkeypatch):
+    """An in-process httpx LLM call is forwarded through the daemon and
+    appears in the daemon's records — same shape as local mode."""
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+
+    tracker = LLMTracker()
+    tracker.start()
+    try:
+        with tracker.track(data_id="dp_1", combo_id="c"):
+            client = httpx.Client(base_url=mock_upstream.base_url)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert resp.status_code == 200
+
+        # Records live on the daemon; fetched via HTTP.
+        records = tracker.get_records(combo_id="c")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.status_code == 200
+        assert rec.error is None
+        assert rec.model == "gpt-4o-mini"
+        # Mock returns usage {prompt_tokens: 10, completion_tokens: 5}.
+        assert rec.prompt_tokens == 10
+        assert rec.completion_tokens == 5
+        assert rec.data_id == "dp_1"
+        assert rec.combo_id == "c"
+
+        # Usage aggregation should reflect the same call.
+        usage = tracker.get_usage(combo_id="c")
+        assert usage == {"gpt-4o-mini": (10, 5)}
+    finally:
+        tracker.stop()
+
+
+def test_remote_get_session_env_points_at_daemon(daemon, monkeypatch):
+    """``get_session_env`` returns the daemon's per-session port + bundle."""
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    tracker = LLMTracker()
+    tracker.start()
+    try:
+        with tracker.track(data_id="dp", combo_id="c") as session:
+            env = tracker.get_session_env(session)
+            assert "HTTPS_PROXY" in env
+            assert env["HTTPS_PROXY"].startswith("http://127.0.0.1:")
+            # Per-session port is distinct from the control-plane port.
+            assert env["HTTPS_PROXY"] != daemon
+            assert env["SSL_CERT_FILE"].endswith("ca-bundle.pem")
+            assert env["REQUESTS_CA_BUNDLE"] == env["SSL_CERT_FILE"]
+            assert env["NODE_EXTRA_CA_CERTS"] == env["SSL_CERT_FILE"]
+    finally:
+        tracker.stop()
+
+
+def test_remote_no_op_endpoints(daemon, monkeypatch):
+    """``flush_cache`` / ``clear_cache`` / empty-query queries don't error."""
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+    tracker = LLMTracker()
+    tracker.start()
+    try:
+        assert tracker.get_records(combo_id="never") == []
+        assert tracker.get_usage(combo_id="never") == {}
+        assert tracker.get_cached_latency(combo_id="never") == 0.0
+        tracker.flush_cache()
+        tracker.clear_cache()
+    finally:
+        tracker.stop()
+
+
+def test_remote_get_records_works_after_stop(daemon, mock_upstream, monkeypatch):
+    """Regression: ``ModelSelector.select_best`` calls ``tracker.get_records()``
+    *after* ``tracker.stop()`` to harvest the run's records.  Stop must not
+    close the control-plane client out from under that follow-up query."""
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", daemon)
+
+    tracker = LLMTracker()
+    tracker.start()
+    with tracker.track(data_id="dp", combo_id="c"):
+        client = httpx.Client(base_url=mock_upstream.base_url)
+        client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    tracker.stop()
+
+    # Must still work — this is what ModelSelector does post-stop.
+    records = tracker.get_records(combo_id="c")
+    assert len(records) == 1
+    assert records[0].model == "gpt-4o-mini"
+
+
+def test_remote_gateway_unreachable_fails_fast(monkeypatch):
+    """A bad ``AGENTOPT_GATEWAY_URL`` raises at ``start()`` with a clear message."""
+    # Pick a port nothing is listening on.
+    monkeypatch.setenv("AGENTOPT_GATEWAY_URL", "http://127.0.0.1:1")
+    tracker = LLMTracker()
+    with pytest.raises(RuntimeError, match="not reachable"):
+        tracker.start()


### PR DESCRIPTION
# Daemon-mode backend for `LLMTracker`

## Summary
- Extracts today's `LLMTracker` lifecycle into a `_Backend` ABC with two impls: `LocalBackend` (today's per-process mitmproxy + httpx patch) and `RemoteBackend` (HTTP client for a long-lived `agentopt serve` daemon).
- Adds `agentopt serve` CLI — an `aiohttp.web` daemon that owns a singleton `LocalBackend` and exposes its surface over HTTP (`/sessions`, `/records`, `/usage`, `/cache/*`, `/providers`, `/ca`, `/health`). Localhost-only; refuses non-127.0.0.1 binds until auth lands.
- Adds a `handler` seam to `interceptor.py`'s `ActiveSession`. The patched `httpx.send` is now a one-line dispatcher; `LocalHandler` holds today's cache+forward+record body; new `RemoteHandler` forwards through the daemon's per-session proxy port.
- `LLMTracker.__init__` picks backend by reading `AGENTOPT_GATEWAY_URL`. **No public API change** — `ModelSelector(...).select_best()` is byte-identical between modes; the env var is the entire deployment switch.

## Why
- Multi-language / multi-process clients (subprocess agents in any language) can share one gateway instead of each spinning its own proxy.
- State (records, cache) can outlive a single experiment.
- Lays the groundwork for scheduling-class features (concurrency caps, coalescing) that need a global view a per-process library can't supply.

## Out of scope (deferred)
- Routing in daemon mode — library-only for now.
- Cache namespacing — shared across daemon clients in v1; users `clear_cache()` for fresh runs.
- Auth, TLS, non-localhost binding.
- OpenAI-compat REST mode (clients use HTTPS_PROXY for v1).

## Test plan
- [x] Full suite: 91 passed (85 existing local-mode tests untouched + 6 new `test_daemon_e2e.py`)
- [x] E2E: `agentopt serve` subprocess + `AGENTOPT_GATEWAY_URL` env var; in-process httpx call appears as a `CallRecord` on the daemon with matching `model` / `prompt_tokens` / `combo_id`
- [x] `get_session_env()` returns daemon's per-session port + bundle path
- [x] Regression: `get_records()` after `stop()` works (the pattern `ModelSelector.select_best` uses)
- [x] Daemon fail-fast: unreachable `AGENTOPT_GATEWAY_URL` raises clear error at `start()`
- [x] Manual smoke: `examples/daemon_example.py` runs identically with and without the env var
