### PR TITLE
fix selector.md

### DIFF
--- a/docs/api/selectors.md
+++ b/docs/api/selectors.md
@@ -102,7 +102,7 @@ Returns a [`SelectionResults`](results.md). `parallel=True` requires `agent.run`
       members: false
       show_bases: false
 
-::: agentopt.model_selection.matrix_ucb_factorization.MatrixUCBLRFModelSelector
+::: agentopt.model_selection.matrix_ucb.MatrixUCBLRFModelSelector
     options:
       members: false
       show_bases: false


### PR DESCRIPTION
[docs/api/selectors.md:105](vscode-webview://1ikco54m9lr1q1u194joh7ukorht9q74kohgp3c8gsfdkdh4416e/docs/api/selectors.md#L105) — module path was matrix_ucb_factorization (which only defines the Factorization helper); corrected to matrix_ucb, where MatrixUCBLRFModelSelector is actually defined.
