### PR TITLE
Add combined objective (latency/cost-weighted) to all model selectors

### DIFF
--- a/.codex/skills/agentopt/SKILL.md
+++ b/.codex/skills/agentopt/SKILL.md
@@ -227,7 +227,7 @@ Candidates may be model-name strings or framework-specific LLM instances, as lon
 | `lm_proposal` | Ask a proposer LLM to pick a combo, then evaluate it. | `proposer_model`, `proposer_client`, `objective`, `dataset_preview_size`, `node_descriptions` |
 | `bayesian` | Surrogate-model-guided search over medium/large spaces. | `batch_size`, `sample_fraction` |
 
-Other `ModelSelector` kwargs: `model_prices` (custom token pricing), `tracker` (e.g. `LLMTracker(cache_dir=...)` for disk-cache reuse), `node_descriptions` (used by `lm_proposal`).
+Other `ModelSelector` kwargs: `model_prices` (custom token pricing), `tracker` (e.g. `LLMTracker(cache_dir=...)` for disk-cache reuse), `node_descriptions` (used by `lm_proposal`), `lambda_cost` / `lambda_latency` (optional; default `0.0` — scalar combined objective `score - λ_cost·norm(cost) - λ_latency·norm(latency)`; see `docs/api/selectors.md#combined-objective-optional-costlatency-weights`).
 
 ### 5. Concurrency
 

--- a/docs/api/results.md
+++ b/docs/api/results.md
@@ -6,7 +6,7 @@ Returned by `selector.select_best()`. Holds every evaluated combination and the 
 
 | Method | Returns | Description |
 |:---|:---|:---|
-| `print_summary()` | `None` | Print a ranked table with accuracy, latency, tokens, and price. |
+| `print_summary()` | `None` | Print a ranked table with accuracy, latency, tokens, and price. When any result has `combined_objective` set, the table sorts by that value. |
 | `get_best(attribute=None)` | `ModelResult?` | The `is_best` combination. Pass `attribute` to scope the lookup to a single metric track. |
 | `get_best_combo()` | `Dict[str, str]?` | Best combination as `{"node": "model_name"}`. |
 | `get_by_attribute(attribute)` | `List[ModelResult]` | All results for a given attribute. |
@@ -40,6 +40,7 @@ One per evaluated combination.
 |:---|:---|:---|
 | `model_name` | `str` | Combination label, e.g. `"planner=gpt-4o + solver=gpt-4o-mini"`. |
 | `accuracy` | `float` | Mean eval score across evaluated datapoints. |
+| `combined_objective` | `float?` | Mean per-datapoint combined score when `lambda_cost` and/or `lambda_latency` were set on the selector; `None` otherwise. See [selectors.md — Combined objective](selectors.md#combined-objective-optional-costlatency-weights). |
 | `latency_seconds` | `float` | Mean latency per datapoint. |
 | `input_tokens` | `Dict[str, int]` | Input tokens by model. |
 | `output_tokens` | `Dict[str, int]` | Output tokens by model. |

--- a/docs/api/selectors.md
+++ b/docs/api/selectors.md
@@ -24,7 +24,9 @@ results.print_summary()
 | `models` | `Dict[str, List]` | Maps node names to candidate model lists (e.g. `{"planner": ["gpt-4o", "gpt-4o-mini"]}`). |
 | `eval_fn` | `Callable` | `(expected, actual) -> float` score (higher is better). |
 | `dataset` | `Sequence[Tuple]` | `[(input_data, expected_answer), ...]`. |
-| `model_prices` | `Dict`, optional | Custom pricing overrides: `{"model": {"input_price": x, "output_price": y}}` in $/MTok. |
+| `model_prices` | `Dict`, optional | Custom pricing overrides: `{"model": {"input_price": x, "output_price": y}}` in $/MTok. Required for cost terms when `lambda_cost > 0`. |
+| `lambda_cost` | `float`, optional | Weight on **normalized** per-sample cost in the combined objective. Default `0.0` (disabled). See [Combined objective](#combined-objective-optional-costlatency-weights) below. |
+| `lambda_latency` | `float`, optional | Weight on **normalized** per-sample latency in the combined objective. Default `0.0` (disabled). |
 | `node_descriptions` | `Dict[str, str]`, optional | Human-readable descriptions per node — surfaced in `LMProposalModelSelector`. |
 | `tracker` | `LLMTracker`, optional | Bring your own. Defaults to a fresh `LLMTracker()` started in the constructor. Pass one in to share a cache across runs, route via a daemon (`AGENTOPT_GATEWAY_URL`), or post-process records after `select_best()` returns. |
 
@@ -38,6 +40,68 @@ print(tracker.get_usage())          # tracker.stop() already called; records sti
 ```
 
 See [tracker.md](tracker.md) for the full tracker surface.
+
+## Combined objective (optional cost/latency weights)
+
+By default, selectors optimize **`eval_fn` score only** (typically accuracy) and break ties with latency, then price. To trade accuracy against cost and latency in one scalar reward, pass optional weights on the constructor (or via `ModelSelector(..., **kwargs)`):
+
+| Parameter | Default | Effect |
+|:---|:---|:---|
+| `lambda_cost` | `0.0` | Penalizes normalized per-sample **token cost** (USD from the tracker, or `model_prices`). |
+| `lambda_latency` | `0.0` | Penalizes normalized per-sample **wall-clock latency** (seconds). |
+
+Omit both parameters (or leave them at `0.0`) for the original accuracy-centric behavior. Set one or both when you want multi-metric selection.
+
+### Formula
+
+For each datapoint, after observations are recorded:
+
+```
+combined = score
+         - lambda_cost    * norm(cost)
+         - lambda_latency * norm(latency)
+```
+
+- **`score`** — return value of `eval_fn` (higher is better).
+- **`norm(·)`** — min–max scale to `[0, 1]` using running min/max over **all** samples seen during that selector run (updated as more combos are evaluated).
+- **Per combination** — mean of per-datapoint combined values → `ModelResult.combined_objective` (see [results.md](results.md)).
+
+This is a **linear scalarization**, not Pareto exploration. Larger `lambda_*` penalize cost/latency more strongly relative to score.
+
+### Example
+
+```python
+selector = ModelSelector(
+    agent=MyAgent,
+    models=models,
+    eval_fn=eval_fn,
+    dataset=dataset,
+    method="matrix_ucb",
+    lambda_cost=0.3,      # optional — omit for accuracy-only
+    lambda_latency=0.2,
+    model_prices={        # recommended when lambda_cost > 0
+        "gpt-4o": {"input_price": 2.5, "output_price": 10.0},
+        "gpt-4o-mini": {"input_price": 0.15, "output_price": 0.6},
+    },
+)
+results = selector.select_best(parallel=True)
+results.print_summary()   # ranks by combined_objective when lambdas are set
+```
+
+### How each method uses the weights
+
+| Methods | During search | Final `is_best` |
+|:---|:---|:---|
+| `matrix_ucb`, `matrix_ucb_lrf` | UCB rewards use per-cell combined objective | `_find_best` on `combined_objective` |
+| `arm_elimination`, `epsilon_lucb`, `threshold` | Elimination / LUCB stats on combined per-sample objectives | same |
+| `hill_climbing`, `bayesian` | Move / surrogate target uses combined objective | same |
+| `brute_force`, `random` | Does not steer *which* combos to try | same |
+| `lm_proposal` | Proposer uses `objective=` **text**, not these lambdas | `combined_objective` on the one evaluated combo only |
+
+After `select_best()`, a final pass recomputes every result’s `combined_objective` against the **full-run** normalizer so rankings are comparable.
+
+!!! note "`lm_proposal` vs lambdas"
+    `LMProposalModelSelector(objective="...")` is a natural-language hint to the **proposer LLM**. It is separate from `lambda_cost` / `lambda_latency`, which only affect the scalar reward used for ranking and bandit methods.
 
 ## `select_best()`
 

--- a/docs/concepts/algorithms.md
+++ b/docs/concepts/algorithms.md
@@ -28,6 +28,8 @@ AgentOpt provides 8 selection algorithms. Choose based on your search space size
     results = selector.select_best(parallel=True, max_concurrent=20)
     ```
 
+    To optionally weight cost and latency against accuracy, pass `lambda_cost` and/or `lambda_latency` (default `0.0`). See [Combined objective](../api/selectors.md#combined-objective-optional-costlatency-weights).
+
 ---
 
 ## Brute Force

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -90,6 +90,6 @@ For each model combination:
 3. **Track** — Record token usage, latency, and cost via the interception layer
 4. **Score** — Evaluate each output using `eval_fn(expected, actual)`
 5. **Aggregate** — Compute mean accuracy, latency, and estimated cost
-6. **Rank** — Sort by accuracy (ties broken by latency), report results
+6. **Rank** — By default, sort by accuracy (ties broken by latency, then price). If you pass optional `lambda_cost` / `lambda_latency` on the selector, rank by the scalar [combined objective](../api/selectors.md#combined-objective-optional-costlatency-weights) instead.
 
 Different [selection algorithms](algorithms.md) vary in how they choose *which* combinations to evaluate, but steps 1-6 are the same for all of them.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -123,6 +123,9 @@ The `models` dict maps each step name (matching the keys your `__init__` expects
 
 With 3 candidates per step and 2 steps, that's 9 combinations. Smart algorithms like `HillClimbingModelSelector` or `BayesianOptimizationModelSelector` can find the best combination without evaluating all of them — and they also select which datapoints to run on, stopping early when the winner is clear.
 
+!!! tip "Optional: trade accuracy for cost or latency"
+    Add `lambda_cost=0.3` and/or `lambda_latency=0.2` to the selector constructor to rank combinations by a scalar combined objective instead of accuracy alone. Omit them (default `0.0`) for accuracy-first selection. Details: [Combined objective](../api/selectors.md#combined-objective-optional-costlatency-weights).
+
 ## Step 5: Use the Results
 
 ```python

--- a/src/agentopt/__init__.py
+++ b/src/agentopt/__init__.py
@@ -137,7 +137,9 @@ def ModelSelector(
             ``"lm_proposal"``, ``"bayesian"``.
         **kwargs: Additional arguments passed to the selector
             (e.g. ``epsilon``, ``threshold``, ``sample_fraction``, ``warmup_fraction``
-            for matrix UCB-LRF).
+            for matrix UCB-LRF; ``lambda_cost``, ``lambda_latency`` for the optional
+            combined objective ``score - lambda_cost*norm_cost -
+            lambda_latency*norm_latency`` — both default to ``0.0`` / accuracy-only).
 
     Returns:
         A selector instance. Call ``.select_best()`` to run.

--- a/src/agentopt/model_selection/arm_elimination.py
+++ b/src/agentopt/model_selection/arm_elimination.py
@@ -29,6 +29,8 @@ class ArmEliminationModelSelector(BaseModelSelector):
         confidence: float = 1.0,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -37,6 +39,8 @@ class ArmEliminationModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         n = len(self.dataset)
         if n_initial is None:
@@ -60,6 +64,9 @@ class ArmEliminationModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(len(all_combos))}
         combo_latencies: Dict[int, List[float]] = {
+            i: [] for i in range(len(all_combos))
+        }
+        combo_costs: Dict[int, List[Optional[float]]] = {
             i: [] for i in range(len(all_combos))
         }
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(len(all_combos))}
@@ -91,17 +98,30 @@ class ArmEliminationModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = self._evaluate_combo(
                     combo, batch, label=combo_name, dp_offset=offset
                 )
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, _ = self._compute_stats(combo_scores[idx])
-                print(f"  {combo_name}: mu={mu:.3f} (n={len(combo_scores[idx])})")
+                objs = self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                mu, _ = self._compute_stats(objs)
+                print(f"  {combo_name}: mu={mu:.3f} (n={len(objs)})")
 
-            # Eliminate dominated combinations.
+            # Eliminate dominated combinations on the current combined objective.
+            arm_objectives = {
+                idx: self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                for idx in active
+            }
             newly_eliminated: Set[int] = set()
             for i in active:
                 for j in active:
-                    if i != j and self._is_dominated(combo_scores[i], combo_scores[j]):
+                    if i != j and self._is_dominated(
+                        arm_objectives[i], arm_objectives[j]
+                    ):
                         newly_eliminated.add(i)
                         break
 
@@ -109,7 +129,7 @@ class ArmEliminationModelSelector(BaseModelSelector):
                 for idx in newly_eliminated:
                     combo_name = self._combo_name(all_combos[idx])
                     winner = self._find_dominator_name(
-                        idx, active - newly_eliminated, all_combos, combo_scores
+                        idx, active - newly_eliminated, all_combos, arm_objectives
                     )
                     print(
                         f"  Eliminated: {combo_name}"
@@ -129,49 +149,10 @@ class ArmEliminationModelSelector(BaseModelSelector):
             batch_size = max(1, int(batch_size * self.growth_factor))
             round_num += 1
 
-        # Build results.
-        all_results: List[ModelResult] = []
-        for idx, combo in enumerate(all_combos):
-            combo_name = self._combo_name(combo)
-            scores = combo_scores[idx]
-            latencies = combo_latencies[idx]
-            dp_ids = combo_dp_ids[idx]
-            if scores:
-                accuracy = sum(scores) / len(scores)
-                avg_latency = sum(latencies) / len(latencies)
-            else:
-                accuracy, avg_latency = 0.0, 0.0
-            input_tokens, output_tokens = self._fetch_tokens(combo_name)
-            dp_results = (
-                self._build_datapoint_results(scores, latencies, dp_ids)
-                if dp_ids
-                else []
-            )
-            all_results.append(
-                self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=avg_latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
-                )
-            )
-
-        best_info = self._find_best(all_results)
-        if best_info is not None:
-            best_name, _ = best_info
-            for result in all_results:
-                if result.model_name == best_name:
-                    result.is_best = True
-                    break
-        else:
-            print("\n  No combinations succeeded.")
-
-        results = SelectionResults(results=all_results)
-        return results
+        all_results = self._build_results(
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
+        )
+        return SelectionResults(results=all_results)
 
     async def _select_async(self, max_concurrent: int = 20) -> SelectionResults:
         all_combos = self._all_combos()
@@ -180,6 +161,9 @@ class ArmEliminationModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(len(all_combos))}
         combo_latencies: Dict[int, List[float]] = {
+            i: [] for i in range(len(all_combos))
+        }
+        combo_costs: Dict[int, List[Optional[float]]] = {
             i: [] for i in range(len(all_combos))
         }
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(len(all_combos))}
@@ -234,19 +218,32 @@ class ArmEliminationModelSelector(BaseModelSelector):
                     logger.warning("Batch evaluation error: %s", res)
                     continue
                 idx, scores, latencies, dp_ids = res
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, _ = self._compute_stats(combo_scores[idx])
+                objs = self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                mu, _ = self._compute_stats(objs)
                 print(
                     f"  {self._combo_name(all_combos[idx])}: "
-                    f"mu={mu:.3f} (n={len(combo_scores[idx])})"
+                    f"mu={mu:.3f} (n={len(objs)})"
                 )
 
+            arm_objectives = {
+                idx: self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                for idx in active
+            }
             newly_eliminated: Set[int] = set()
             for i in active:
                 for j in active:
-                    if i != j and self._is_dominated(combo_scores[i], combo_scores[j]):
+                    if i != j and self._is_dominated(
+                        arm_objectives[i], arm_objectives[j]
+                    ):
                         newly_eliminated.add(i)
                         break
 
@@ -254,7 +251,7 @@ class ArmEliminationModelSelector(BaseModelSelector):
                 for idx in newly_eliminated:
                     combo_name = self._combo_name(all_combos[idx])
                     winner = self._find_dominator_name(
-                        idx, active - newly_eliminated, all_combos, combo_scores
+                        idx, active - newly_eliminated, all_combos, arm_objectives
                     )
                     print(
                         f"  Eliminated: {combo_name}"
@@ -274,48 +271,10 @@ class ArmEliminationModelSelector(BaseModelSelector):
             batch_size = max(1, int(batch_size * self.growth_factor))
             round_num += 1
 
-        all_results: List[ModelResult] = []
-        for idx, combo in enumerate(all_combos):
-            combo_name = self._combo_name(combo)
-            scores = combo_scores[idx]
-            latencies = combo_latencies[idx]
-            dp_ids = combo_dp_ids[idx]
-            if scores:
-                accuracy = sum(scores) / len(scores)
-                avg_latency = sum(latencies) / len(latencies)
-            else:
-                accuracy, avg_latency = 0.0, 0.0
-            input_tokens, output_tokens = self._fetch_tokens(combo_name)
-            dp_results = (
-                self._build_datapoint_results(scores, latencies, dp_ids)
-                if dp_ids
-                else []
-            )
-            all_results.append(
-                self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=avg_latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
-                )
-            )
-
-        best_info = self._find_best(all_results)
-        if best_info is not None:
-            best_name, _ = best_info
-            for result in all_results:
-                if result.model_name == best_name:
-                    result.is_best = True
-                    break
-        else:
-            print("\n  No combinations succeeded.")
-
-        results = SelectionResults(results=all_results)
-        return results
+        all_results = self._build_results(
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
+        )
+        return SelectionResults(results=all_results)
 
     # ------------------------------------------------------------------
     # Statistical helpers
@@ -337,9 +296,58 @@ class ArmEliminationModelSelector(BaseModelSelector):
         dominated_idx: int,
         active_remaining: Set[int],
         all_combos: List[Dict[str, ModelCandidate]],
-        combo_scores: Dict[int, List[float]],
+        arm_values: Dict[int, List[float]],
     ) -> Optional[str]:
+        """Find the name of an arm that dominates ``dominated_idx`` on ``arm_values``."""
         for j in active_remaining:
-            if self._is_dominated(combo_scores[dominated_idx], combo_scores[j]):
+            if self._is_dominated(arm_values[dominated_idx], arm_values[j]):
                 return self._combo_name(all_combos[j])
         return None
+
+    def _build_results(
+        self,
+        all_combos: List[Dict[str, ModelCandidate]],
+        combo_scores: Dict[int, List[float]],
+        combo_latencies: Dict[int, List[float]],
+        combo_costs: Dict[int, List[Optional[float]]],
+        combo_dp_ids: Dict[int, List[str]],
+    ) -> List[ModelResult]:
+        """Build final per-combo results, finalize the combined objective, mark best."""
+        all_results: List[ModelResult] = []
+        for idx, combo in enumerate(all_combos):
+            combo_name = self._combo_name(combo)
+            scores = combo_scores[idx]
+            if scores:
+                all_results.append(
+                    self._build_combo_result(
+                        combo_name,
+                        scores,
+                        combo_latencies[idx],
+                        combo_dp_ids[idx],
+                        costs=combo_costs[idx],
+                    )
+                )
+            else:
+                all_results.append(
+                    self._make_result(
+                        model_name=combo_name,
+                        accuracy=0.0,
+                        latency_seconds=0.0,
+                        input_tokens={},
+                        output_tokens={},
+                        attribute="combination",
+                        is_best=False,
+                    )
+                )
+
+        self._finalize_combined_objectives(all_results)
+        best_info = self._find_best(all_results)
+        if best_info is not None:
+            best_name, _ = best_info
+            for result in all_results:
+                if result.model_name == best_name:
+                    result.is_best = True
+                    break
+        else:
+            print("\n  No combinations succeeded.")
+        return all_results

--- a/src/agentopt/model_selection/base.py
+++ b/src/agentopt/model_selection/base.py
@@ -48,6 +48,14 @@ class ModelResult(BaseModel):
     attribute: str
     is_best: bool = False
     datapoint_results: List[DatapointResult] = Field(default_factory=list)
+    combined_objective: Optional[float] = Field(
+        default=None,
+        description=(
+            "Per-sample mean of the combined objective "
+            "(score - lambda_cost*norm_cost - lambda_latency*norm_latency). "
+            "None when no lambdas were configured."
+        ),
+    )
     _custom_prices: Optional[Dict[str, Tuple[float, float]]] = PrivateAttr(default=None)
 
     @property
@@ -710,6 +718,8 @@ class BaseModelSelector(ABC):
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         node_descriptions: Optional[Dict[str, str]] = None,
         tracker: Optional[LLMTracker] = None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         """
         Initialize the model selector.
@@ -734,11 +744,20 @@ class BaseModelSelector(ABC):
                 ``{"planner": "Decomposes queries into sub-tasks"}``.
             tracker: Optional :class:`LLMTracker` instance. If not provided,
                 one is created and started automatically.
+            lambda_cost: Weight on normalized per-sample cost in the combined
+                objective ``score - lambda_cost*norm_cost - lambda_latency*norm_latency``.
+                Cost is normalized adaptively against the running min/max of all
+                samples observed during this selector's lifetime. Default 0.0
+                (pure accuracy, backwards compatible).
+            lambda_latency: Weight on normalized per-sample latency in the
+                combined objective. Default 0.0.
         """
         if agent is None:
             raise TypeError("'agent' is required")
         if models is None or eval_fn is None or dataset is None:
             raise TypeError("'models', 'eval_fn', and 'dataset' are required")
+        if float(lambda_cost) < 0 or float(lambda_latency) < 0:
+            raise ValueError("lambda_cost and lambda_latency must be non-negative")
 
         validate_dataset(dataset)
 
@@ -758,6 +777,14 @@ class BaseModelSelector(ABC):
         self._node_names = list(models.keys())
         self.model_prices = model_prices
         self.node_descriptions = node_descriptions
+        self.lambda_cost = float(lambda_cost)
+        self.lambda_latency = float(lambda_latency)
+
+        # Running min/max for adaptive [0,1] normalization of cost/latency.
+        self._cost_min: float = float("inf")
+        self._cost_max: float = float("-inf")
+        self._latency_min: float = float("inf")
+        self._latency_max: float = float("-inf")
 
         # Detect whether agent.run() is async
         run_method = getattr(agent, "run", None)
@@ -965,6 +992,157 @@ class BaseModelSelector(ABC):
         return result
 
     # ------------------------------------------------------------------
+    # Combined objective (cost / latency weighted)
+    # ------------------------------------------------------------------
+
+    @property
+    def _has_combined_objective(self) -> bool:
+        """True when at least one of the cost/latency lambdas is nonzero."""
+        return self.lambda_cost > 0.0 or self.lambda_latency > 0.0
+
+    def _per_sample_costs(self, dp_ids: List[str]) -> List[Optional[float]]:
+        """Look up per-datapoint cost from tracked tokens; ``None`` if unpriced."""
+        if not dp_ids:
+            return []
+        by_dp = self._fetch_tokens_by_datapoint(dp_ids)
+        costs: List[Optional[float]] = []
+        for dp_id in dp_ids:
+            in_tok, out_tok = by_dp.get(dp_id, ({}, {}))
+            costs.append(
+                compute_price(in_tok, out_tok, custom_prices=self._custom_prices)
+            )
+        return costs
+
+    def _absorb_observations(
+        self, latencies: List[float], costs: List[Optional[float]],
+    ) -> None:
+        """Update the running min/max with new samples."""
+        if not self._has_combined_objective:
+            return
+        for lat in latencies:
+            if lat is None or not math.isfinite(lat):
+                continue
+            if lat < self._latency_min:
+                self._latency_min = lat
+            if lat > self._latency_max:
+                self._latency_max = lat
+        for c in costs:
+            if c is None or not math.isfinite(c):
+                continue
+            if c < self._cost_min:
+                self._cost_min = c
+            if c > self._cost_max:
+                self._cost_max = c
+
+    @staticmethod
+    def _minmax_norm(value: Optional[float], lo: float, hi: float) -> float:
+        """Min-max normalize to [0,1]; returns 0.0 if value/range is degenerate."""
+        if value is None or not math.isfinite(value):
+            return 0.0
+        if not math.isfinite(lo) or not math.isfinite(hi) or hi <= lo:
+            return 0.0
+        return (value - lo) / (hi - lo)
+
+    def _combined_objective(
+        self, score: float, latency: float, cost: Optional[float],
+    ) -> float:
+        """Per-sample combined objective, computed against the current normalizer."""
+        if not self._has_combined_objective:
+            return score
+        norm_lat = self._minmax_norm(latency, self._latency_min, self._latency_max)
+        norm_cost = self._minmax_norm(cost, self._cost_min, self._cost_max)
+        return (
+            score
+            - self.lambda_cost * norm_cost
+            - self.lambda_latency * norm_lat
+        )
+
+    def _compute_objectives(
+        self,
+        scores: List[float],
+        latencies: List[float],
+        costs: List[Optional[float]],
+    ) -> List[float]:
+        """Vectorized per-sample combined objectives using current normalizer."""
+        if not self._has_combined_objective:
+            return list(scores)
+        return [
+            self._combined_objective(s, lat, c)
+            for s, lat, c in zip(scores, latencies, costs)
+        ]
+
+    def _mean_objective(
+        self,
+        scores: List[float],
+        latencies: List[float],
+        costs: List[Optional[float]],
+    ) -> Optional[float]:
+        """Mean combined objective across samples, or ``None`` if no lambdas set."""
+        if not self._has_combined_objective or not scores:
+            return None
+        objs = self._compute_objectives(scores, latencies, costs)
+        return sum(objs) / len(objs)
+
+    def _observe_combo(
+        self,
+        scores: List[float],
+        latencies: List[float],
+        dp_ids: List[str],
+    ) -> List[Optional[float]]:
+        """Fetch per-sample costs and absorb them into the running normalizer.
+
+        Returns the per-sample costs aligned with ``scores`` / ``latencies``.
+        Always returns a list (possibly all ``None`` if pricing is unavailable);
+        selectors can cache it alongside scores/latencies for later objective
+        recomputation when the normalizer changes.
+        """
+        costs = self._per_sample_costs(dp_ids)
+        self._absorb_observations(latencies, costs)
+        return costs
+
+    def _recover_costs(self, result: ModelResult) -> List[Optional[float]]:
+        """Reconstruct per-sample costs for a finalized result from its dp tokens."""
+        return [
+            compute_price(
+                dp.input_tokens,
+                dp.output_tokens,
+                custom_prices=result._custom_prices,
+            )
+            for dp in result.datapoint_results
+        ]
+
+    def _finalize_combined_objectives(self, results: List[ModelResult]) -> None:
+        """Recompute ``combined_objective`` on every result using all observed data.
+
+        Selectors typically evaluate combos in arbitrary order. ``_build_combo_result``
+        sets ``combined_objective`` against the normalizer at observation time;
+        this pass rebuilds it against the **final** normalizer so that all
+        results are ranked on a consistent scale.
+
+        Idempotent and a no-op when no lambdas are configured.
+        """
+        if not self._has_combined_objective:
+            return
+
+        # Pass 1: absorb every result's samples so the normalizer reflects the
+        # full set (cheap; observe_combo during search may have missed some
+        # samples if a selector skipped it).
+        cached: List[Tuple[ModelResult, List[float], List[float], List[Optional[float]]]] = []
+        for r in results:
+            if not r.datapoint_results:
+                cached.append((r, [], [], []))
+                continue
+            scores = [dp.score for dp in r.datapoint_results]
+            lats = [dp.latency_seconds for dp in r.datapoint_results]
+            costs = self._recover_costs(r)
+            self._absorb_observations(lats, costs)
+            cached.append((r, scores, lats, costs))
+
+        # Pass 2: recompute objectives against the now-final normalizer.
+        for r, scores, lats, costs in cached:
+            r.combined_objective = self._mean_objective(scores, lats, costs)
+
+    # ------------------------------------------------------------------
     # Result helpers
     # ------------------------------------------------------------------
 
@@ -973,6 +1151,49 @@ class BaseModelSelector(ABC):
         result = ModelResult(**kwargs)
         result._custom_prices = self._custom_prices
         return result
+
+    def _build_combo_result(
+        self,
+        combo_name: str,
+        scores: List[float],
+        latencies: List[float],
+        dp_ids: List[str],
+        costs: Optional[List[Optional[float]]] = None,
+        attribute: str = "combination",
+        is_best: bool = False,
+    ) -> ModelResult:
+        """Build a :class:`ModelResult` and absorb the samples into the normalizer.
+
+        Centralizes the boilerplate selectors share for end-of-search result
+        construction. Computes accuracy, average latency, datapoint results,
+        token totals, and (when ``lambda_cost``/``lambda_latency`` are set)
+        the mean combined objective using the current running normalizer.
+
+        ``costs`` may be passed if the selector already cached per-sample costs
+        during search; otherwise they are looked up from the tracker.
+        """
+        input_tokens, output_tokens = self._fetch_tokens(combo_name)
+        accuracy, _ = self._compute_stats(scores)
+        avg_latency = sum(latencies) / len(latencies) if latencies else 0.0
+        dp_results = (
+            self._build_datapoint_results(scores, latencies, dp_ids) if dp_ids else []
+        )
+        if costs is None:
+            costs = self._observe_combo(scores, latencies, dp_ids)
+        else:
+            self._absorb_observations(latencies, costs)
+        combined = self._mean_objective(scores, latencies, costs)
+        return self._make_result(
+            model_name=combo_name,
+            accuracy=accuracy,
+            latency_seconds=avg_latency,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            attribute=attribute,
+            is_best=is_best,
+            datapoint_results=dp_results,
+            combined_objective=combined,
+        )
 
     def _build_datapoint_results(
         self, scores: List[float], latencies: List[float], datapoint_ids: List[str],
@@ -1005,39 +1226,50 @@ class BaseModelSelector(ABC):
 
     @staticmethod
     def _find_best(results: List[ModelResult]) -> Optional[Tuple[str, float]]:
-        """Find best result by accuracy > latency > cost tiebreaker."""
+        """Find the best result.
+
+        When any result has ``combined_objective`` set, picks the result with
+        the highest combined objective (latency/cost tiebreakers within ties).
+        Otherwise falls back to accuracy > latency > cost.
+        """
+        has_combined = any(r.combined_objective is not None for r in results)
         best = None
-        best_accuracy = float("-inf")
+        best_primary = float("-inf")
         best_latency = float("inf")
         best_cost = float("inf")
         tol = 1e-9
 
         for r in results:
+            primary = (
+                r.combined_objective
+                if has_combined and r.combined_objective is not None
+                else r.accuracy
+            )
             r_cost = r.price if r.price is not None else float("inf")
-            if r.accuracy > best_accuracy + tol:
+            if primary > best_primary + tol:
                 best = r
-                best_accuracy = r.accuracy
+                best_primary = primary
                 best_latency = r.latency_seconds
                 best_cost = r_cost
             elif (
-                abs(r.accuracy - best_accuracy) <= tol
+                abs(primary - best_primary) <= tol
                 and r.latency_seconds < best_latency - tol
             ):
                 best = r
-                best_accuracy = r.accuracy
+                best_primary = primary
                 best_latency = r.latency_seconds
                 best_cost = r_cost
             elif (
-                abs(r.accuracy - best_accuracy) <= tol
+                abs(primary - best_primary) <= tol
                 and abs(r.latency_seconds - best_latency) <= tol
                 and r_cost < best_cost - tol
             ):
                 best = r
-                best_accuracy = r.accuracy
+                best_primary = primary
                 best_latency = r.latency_seconds
                 best_cost = r_cost
 
-        return (best.model_name, best.accuracy) if best else None
+        return (best.model_name, best_primary) if best else None
 
     @staticmethod
     def _compute_stats(scores: List[float]) -> Tuple[float, float]:

--- a/src/agentopt/model_selection/bayesian_optimization.py
+++ b/src/agentopt/model_selection/bayesian_optimization.py
@@ -42,6 +42,8 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
         sample_fraction: float = 0.25,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -50,6 +52,8 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         _require_botorch()
         self.batch_size = max(1, int(batch_size))
@@ -189,6 +193,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
         return [unseen[i] for i in topk]
 
     def _bo_finalize(self, all_results: List[ModelResult]) -> SelectionResults:
+        self._finalize_combined_objectives(all_results)
         best_info = self._find_best(all_results)
         if best_info is not None:
             best_name, _ = best_info
@@ -200,6 +205,41 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
             logger.warning("No successful evaluations.")
         return SelectionResults(results=all_results)
 
+    def _bo_target_from_result(self, result: ModelResult) -> float:
+        """BO target: combined objective if lambdas set, else accuracy."""
+        if not self._has_combined_objective or not result.datapoint_results:
+            return result.accuracy
+        scores = [dp.score for dp in result.datapoint_results]
+        lats = [dp.latency_seconds for dp in result.datapoint_results]
+        from ..model_price import compute_price
+
+        costs = [
+            compute_price(
+                dp.input_tokens, dp.output_tokens, custom_prices=self._custom_prices,
+            )
+            for dp in result.datapoint_results
+        ]
+        obj = self._mean_objective(scores, lats, costs)
+        return obj if obj is not None else result.accuracy
+
+    def _bo_refresh_targets(
+        self, X_list: List[List[int]], Y_list: List[float],
+        results_by_index: Dict[Tuple[int, ...], ModelResult],
+    ) -> None:
+        """Recompute all Y_list entries against the current normalizer.
+
+        Called before each GP fit so the surrogate is trained on objectives
+        normalized with all observations to date.
+        """
+        if not self._has_combined_objective:
+            return
+        for i, x in enumerate(X_list):
+            key = tuple(x)
+            result = results_by_index.get(key)
+            if result is None:
+                continue
+            Y_list[i] = self._bo_target_from_result(result)
+
     def _bo_eval_single(
         self,
         combo: Tuple[int, ...],
@@ -210,6 +250,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
         X_list: List[List[int]],
         Y_list: List[float],
         all_results: List[ModelResult],
+        results_by_index: Dict[Tuple[int, ...], ModelResult],
         label: str,
     ) -> bool:
         """Evaluate a single combo, record results. Returns True on success."""
@@ -222,7 +263,6 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 combo
             )
             X_list.append(list(combo))
-            Y_list.append(accuracy)
             result = self._bo_record_result(
                 combo_name,
                 accuracy,
@@ -232,6 +272,8 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 dp_results,
                 all_results,
             )
+            results_by_index[tuple(combo)] = result
+            Y_list.append(self._bo_target_from_result(result))
             print(f"  {label}{result}")
             return True
         except Exception as e:
@@ -285,6 +327,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
         X_list: List[List[int]] = []
         Y_list: List[float] = []
         all_results: List[ModelResult] = []
+        results_by_index: Dict[Tuple[int, ...], ModelResult] = {}
 
         def evaluate_combo(combo: Tuple[int, ...]) -> Tuple:
             combo_dict = self._bo_index_combo_to_dict(
@@ -294,6 +337,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
             scores, latencies, dp_ids = self._evaluate_combo(
                 combo_dict, self.dataset, label=combo_name
             )
+            self._observe_combo(scores, latencies, dp_ids)
             input_tokens, output_tokens = self._fetch_tokens(combo_name)
             accuracy, _ = self._compute_stats(scores)
             latency = sum(latencies) / len(latencies) if latencies else 0.0
@@ -326,6 +370,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 X_list,
                 Y_list,
                 all_results,
+                results_by_index,
                 label="",
             )
 
@@ -350,10 +395,12 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                     X_list,
                     Y_list,
                     all_results,
+                    results_by_index,
                     label="",
                 )
                 continue
 
+            self._bo_refresh_targets(X_list, Y_list, results_by_index)
             batch = self._bo_fit_and_acquire(
                 torch_mod,
                 LogExpectedImprovement,
@@ -386,6 +433,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                     X_list,
                     Y_list,
                     all_results,
+                    results_by_index,
                     label=f"[BO {it+1}/{n_iterations} | {j}/{len(batch)}] ",
                 )
 
@@ -416,6 +464,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
         X_list: List[List[int]] = []
         Y_list: List[float] = []
         all_results: List[ModelResult] = []
+        results_by_index: Dict[Tuple[int, ...], ModelResult] = {}
 
         async def evaluate_combo(
             combo: Tuple[int, ...], dp_concurrent: int = max_concurrent,
@@ -430,6 +479,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 label=combo_name,
                 max_concurrent=dp_concurrent,
             )
+            self._observe_combo(scores, latencies, dp_ids)
             input_tokens, output_tokens = self._fetch_tokens(combo_name)
             accuracy, _ = self._compute_stats(scores)
             latency = sum(latencies) / len(latencies) if latencies else 0.0
@@ -449,7 +499,6 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 dp_results,
             ) = await evaluate_combo(combo)
             X_list.append(list(combo))
-            Y_list.append(accuracy)
             result = self._bo_record_result(
                 combo_name,
                 accuracy,
@@ -459,6 +508,8 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                 dp_results,
                 all_results,
             )
+            results_by_index[tuple(combo)] = result
+            Y_list.append(self._bo_target_from_result(result))
             print(f"  {label}{result}")
             return True
 
@@ -521,6 +572,7 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                     logger.warning("[random] [%s] failed: %s", combo_name, e)
                 continue
 
+            self._bo_refresh_targets(X_list, Y_list, results_by_index)
             batch = self._bo_fit_and_acquire(
                 torch_mod,
                 LogExpectedImprovement,
@@ -570,7 +622,6 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                     continue
                 accuracy, latency, input_tokens, output_tokens, dp_results = res
                 X_list.append(list(combo))
-                Y_list.append(accuracy)
                 result = self._bo_record_result(
                     combo_name,
                     accuracy,
@@ -580,6 +631,8 @@ class BayesianOptimizationModelSelector(BaseModelSelector):
                     dp_results,
                     all_results,
                 )
+                results_by_index[tuple(combo)] = result
+                Y_list.append(self._bo_target_from_result(result))
                 print(f"  [BO {it+1}/{n_iterations} | {j}/{len(batch)}] {result}")
 
         return self._bo_finalize(all_results)

--- a/src/agentopt/model_selection/brute_force.py
+++ b/src/agentopt/model_selection/brute_force.py
@@ -25,6 +25,8 @@ class BruteForceModelSelector(BaseModelSelector):
         dataset: Dataset = None,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -33,6 +35,8 @@ class BruteForceModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
 
     def _run_selection(
@@ -46,10 +50,6 @@ class BruteForceModelSelector(BaseModelSelector):
         all_combos = self._all_combos()
 
         all_results: List[ModelResult] = []
-        best_combo_name = None
-        best_accuracy = float("-inf")
-        best_latency = float("inf")
-        tol = 1e-9
 
         print(f"\n{'='*60}")
         print(f"Brute force (sequential): {len(all_combos)} combinations")
@@ -63,30 +63,11 @@ class BruteForceModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = self._evaluate_combo(
                     combo, self.dataset, label=combo_name
                 )
-                input_tokens, output_tokens = self._fetch_tokens(combo_name)
-                accuracy, _ = self._compute_stats(scores)
-                latency = sum(latencies) / len(latencies) if latencies else 0.0
-                dp_results = self._build_datapoint_results(scores, latencies, dp_ids)
-
-                result = self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                result = self._build_combo_result(
+                    combo_name, scores, latencies, dp_ids,
                 )
                 print(f"  {result}")
                 all_results.append(result)
-
-                if (accuracy > best_accuracy + tol) or (
-                    abs(accuracy - best_accuracy) <= tol and latency < best_latency
-                ):
-                    best_accuracy = accuracy
-                    best_latency = latency
-                    best_combo_name = combo_name
 
             except Exception as e:
                 print(f"  [{combo_name}] failed: {e}")
@@ -102,9 +83,12 @@ class BruteForceModelSelector(BaseModelSelector):
                     )
                 )
 
-        if best_combo_name is not None:
+        self._finalize_combined_objectives(all_results)
+        best_info = self._find_best(all_results)
+        if best_info is not None:
+            best_name, _ = best_info
             for result in all_results:
-                if result.model_name == best_combo_name:
+                if result.model_name == best_name:
                     result.is_best = True
                     break
         else:
@@ -137,20 +121,8 @@ class BruteForceModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = await self._evaluate_combo_async(
                     combo, self.dataset, label=combo_name, max_concurrent=dp_concurrent
                 )
-                input_tokens, output_tokens = self._fetch_tokens(combo_name)
-                accuracy, _ = self._compute_stats(scores)
-                latency = sum(latencies) / len(latencies) if latencies else 0.0
-                dp_results = self._build_datapoint_results(scores, latencies, dp_ids)
-
-                result = self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                result = self._build_combo_result(
+                    combo_name, scores, latencies, dp_ids,
                 )
                 print(f"  {result}")
                 return combo_name, result
@@ -179,6 +151,7 @@ class BruteForceModelSelector(BaseModelSelector):
                 _, result = res
                 all_results.append(result)
 
+        self._finalize_combined_objectives(all_results)
         best_info = self._find_best(all_results)
         if best_info is not None:
             best_name, _ = best_info

--- a/src/agentopt/model_selection/epsilon_lucb.py
+++ b/src/agentopt/model_selection/epsilon_lucb.py
@@ -29,6 +29,8 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
         confidence: float = 1.0,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -37,6 +39,8 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         self.epsilon = max(0.0, float(epsilon))
         self.n_initial = max(1, int(n_initial))
@@ -57,6 +61,7 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(n_arms)}
         combo_latencies: Dict[int, List[float]] = {i: [] for i in range(n_arms)}
+        combo_costs: Dict[int, List[Optional[float]]] = {i: [] for i in range(n_arms)}
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(n_arms)}
         active: Set[int] = set(range(n_arms))
 
@@ -77,14 +82,18 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
             scores, latencies, dp_ids = self._evaluate_combo(
                 combo, init_batch, label=combo_name, dp_offset=offset
             )
+            costs = self._observe_combo(scores, latencies, dp_ids)
             combo_scores[idx].extend(scores)
             combo_latencies[idx].extend(latencies)
+            combo_costs[idx].extend(costs)
             combo_dp_ids[idx].extend(dp_ids)
         offset += init_batch_size
 
         round_num = 1
         while active and offset < n_total:
-            h_idx, l_idx, h_lcb, l_ucb = self._choose_lucb_pair(active, combo_scores)
+            h_idx, l_idx, h_lcb, l_ucb = self._choose_lucb_pair(
+                active, combo_scores, combo_latencies, combo_costs
+            )
             gap = l_ucb - h_lcb
             if gap <= self.epsilon or l_idx is None:
                 break
@@ -105,16 +114,21 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = self._evaluate_combo(
                     combo, batch, label=combo_name, dp_offset=offset - 1
                 )
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, _ = self._compute_stats(combo_scores[idx])
-                print(f"  {combo_name}: mu={mu:.3f} (n={len(combo_scores[idx])})")
+                objs = self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                mu, _ = self._compute_stats(objs)
+                print(f"  {combo_name}: mu={mu:.3f} (n={len(objs)})")
 
             round_num += 1
 
         return self._build_results(
-            all_combos, combo_scores, combo_latencies, combo_dp_ids
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
         )
 
     async def _select_async(self, max_concurrent: int = 20) -> SelectionResults:
@@ -125,6 +139,7 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(n_arms)}
         combo_latencies: Dict[int, List[float]] = {i: [] for i in range(n_arms)}
+        combo_costs: Dict[int, List[Optional[float]]] = {i: [] for i in range(n_arms)}
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(n_arms)}
         active: Set[int] = set(range(n_arms))
 
@@ -168,8 +183,10 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
                 logger.warning("Initial LUCB batch evaluation error: %s", res)
                 continue
             idx, scores, latencies, dp_ids = res
+            costs = self._observe_combo(scores, latencies, dp_ids)
             combo_scores[idx].extend(scores)
             combo_latencies[idx].extend(latencies)
+            combo_costs[idx].extend(costs)
             combo_dp_ids[idx].extend(dp_ids)
         offset += init_batch_size
 
@@ -181,7 +198,9 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
         round_combo_sem = asyncio.Semaphore(n_combo_round)
 
         while active and offset < n_total:
-            h_idx, l_idx, h_lcb, l_ucb = self._choose_lucb_pair(active, combo_scores)
+            h_idx, l_idx, h_lcb, l_ucb = self._choose_lucb_pair(
+                active, combo_scores, combo_latencies, combo_costs
+            )
             gap = l_ucb - h_lcb
             if gap <= self.epsilon or l_idx is None:
                 break
@@ -219,27 +238,39 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
                     logger.warning("LUCB pair evaluation error: %s", res)
                     continue
                 idx, scores, latencies, dp_ids = res
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, _ = self._compute_stats(combo_scores[idx])
+                objs = self._compute_objectives(
+                    combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+                )
+                mu, _ = self._compute_stats(objs)
                 print(
                     f"  {self._combo_name(all_combos[idx])}: "
-                    f"mu={mu:.3f} (n={len(combo_scores[idx])})"
+                    f"mu={mu:.3f} (n={len(objs)})"
                 )
 
             round_num += 1
 
         return self._build_results(
-            all_combos, combo_scores, combo_latencies, combo_dp_ids
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
         )
 
     def _choose_lucb_pair(
-        self, active: Set[int], combo_scores: Dict[int, List[float]],
+        self,
+        active: Set[int],
+        combo_scores: Dict[int, List[float]],
+        combo_latencies: Dict[int, List[float]],
+        combo_costs: Dict[int, List[Optional[float]]],
     ) -> Tuple[int, Optional[int], float, float]:
         stats: Dict[int, Tuple[float, float, float]] = {}
         for idx in active:
-            stats[idx] = self._confidence_bounds(combo_scores[idx])
+            objs = self._compute_objectives(
+                combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+            )
+            stats[idx] = self._confidence_bounds(objs)
 
         h_idx = max(active, key=lambda i: stats[i][0])  # highest empirical mean
         if len(active) == 1:
@@ -252,11 +283,11 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
         l_ucb = stats[l_idx][2]
         return h_idx, l_idx, h_lcb, l_ucb
 
-    def _confidence_bounds(self, scores: List[float]) -> Tuple[float, float, float]:
-        n = len(scores)
+    def _confidence_bounds(self, values: List[float]) -> Tuple[float, float, float]:
+        n = len(values)
         if n == 0:
             return 0.0, float("-inf"), float("inf")
-        mu, std = self._compute_stats(scores)
+        mu, std = self._compute_stats(values)
         se = std / math.sqrt(n)
         radius = self.confidence * se
         return mu, mu - radius, mu + radius
@@ -266,38 +297,37 @@ class EpsilonLUCBModelSelector(BaseModelSelector):
         all_combos: List[Dict[str, ModelCandidate]],
         combo_scores: Dict[int, List[float]],
         combo_latencies: Dict[int, List[float]],
+        combo_costs: Dict[int, List[Optional[float]]],
         combo_dp_ids: Dict[int, List[str]],
     ) -> SelectionResults:
         all_results: List[ModelResult] = []
         for idx, combo in enumerate(all_combos):
             combo_name = self._combo_name(combo)
             scores = combo_scores[idx]
-            latencies = combo_latencies[idx]
-            dp_ids = combo_dp_ids[idx]
             if scores:
-                accuracy = sum(scores) / len(scores)
-                avg_latency = sum(latencies) / len(latencies)
-            else:
-                accuracy, avg_latency = 0.0, 0.0
-            input_tokens, output_tokens = self._fetch_tokens(combo_name)
-            dp_results = (
-                self._build_datapoint_results(scores, latencies, dp_ids)
-                if dp_ids
-                else []
-            )
-            all_results.append(
-                self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=avg_latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                all_results.append(
+                    self._build_combo_result(
+                        combo_name,
+                        scores,
+                        combo_latencies[idx],
+                        combo_dp_ids[idx],
+                        costs=combo_costs[idx],
+                    )
                 )
-            )
+            else:
+                all_results.append(
+                    self._make_result(
+                        model_name=combo_name,
+                        accuracy=0.0,
+                        latency_seconds=0.0,
+                        input_tokens={},
+                        output_tokens={},
+                        attribute="combination",
+                        is_best=False,
+                    )
+                )
 
+        self._finalize_combined_objectives(all_results)
         best_info = self._find_best(all_results)
         if best_info is not None:
             best_name, _ = best_info

--- a/src/agentopt/model_selection/hill_climbing.py
+++ b/src/agentopt/model_selection/hill_climbing.py
@@ -10,6 +10,7 @@ import random
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from ..base_models import Dataset, EvalFn, ModelCandidate
+from ..model_price import compute_price
 from ..model_topology import get_faster_neighbor, get_higher_quality_neighbor
 from .base import BaseModelSelector, DatapointResult, ModelResult, SelectionResults
 
@@ -30,6 +31,8 @@ class HillClimbingModelSelector(BaseModelSelector):
         batch_size: int = 1,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -38,6 +41,8 @@ class HillClimbingModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         self.max_iterations = max_iterations
         self.num_restarts = num_restarts
@@ -55,6 +60,27 @@ class HillClimbingModelSelector(BaseModelSelector):
             str,
             Tuple[float, float, Dict[str, int], Dict[str, int], List[DatapointResult]],
         ] = {}
+
+    def _objective_from_dp(self, dp_results: List[DatapointResult]) -> Optional[float]:
+        """Recompute the mean combined objective from cached datapoint results."""
+        if not self._has_combined_objective or not dp_results:
+            return None
+        scores = [dp.score for dp in dp_results]
+        lats = [dp.latency_seconds for dp in dp_results]
+        costs = [
+            compute_price(
+                dp.input_tokens, dp.output_tokens, custom_prices=self._custom_prices,
+            )
+            for dp in dp_results
+        ]
+        return self._mean_objective(scores, lats, costs)
+
+    def _primary_value(
+        self, accuracy: float, dp_results: List[DatapointResult],
+    ) -> float:
+        """Ranking key for tiebreaks: combined objective if configured, else accuracy."""
+        obj = self._objective_from_dp(dp_results)
+        return obj if obj is not None else accuracy
 
     # ------------------------------------------------------------------
     # Shared helpers
@@ -78,7 +104,8 @@ class HillClimbingModelSelector(BaseModelSelector):
     ) -> Tuple[
         str, float, float, Dict[str, int], Dict[str, int], List[DatapointResult], bool
     ]:
-        """Compute stats, cache, and return the standard eval tuple."""
+        """Compute stats, absorb cost samples, cache, and return the eval tuple."""
+        self._observe_combo(scores, latencies, dp_ids)
         input_tokens, output_tokens = self._fetch_tokens(combo_name)
         accuracy, _ = self._compute_stats(scores)
         latency = sum(latencies) / len(latencies) if latencies else 0.0
@@ -189,28 +216,33 @@ class HillClimbingModelSelector(BaseModelSelector):
         eval_results: List[Tuple],
         neighbors: List[Dict[str, ModelCandidate]],
         seen: Set[str],
-        current_accuracy: float,
+        current_value: float,
         current_latency: float,
         tol: float,
     ) -> Optional[Dict[str, ModelCandidate]]:
-        """Select the best neighbor from eval results, or None if none improves."""
+        """Select the best neighbor from eval results, or None if none improves.
+
+        Ranks by primary value (combined objective when ``lambda_*`` are set,
+        else accuracy), with latency as the tiebreaker.
+        """
         best_neighbor: Optional[Dict[str, ModelCandidate]] = None
-        best_n_acc = float("-inf")
+        best_n_val = float("-inf")
         best_n_lat = float("inf")
 
         for neighbor, eval_result in zip(neighbors, eval_results):
-            n_name, n_acc, n_lat, *_ = eval_result
+            n_name, n_acc, n_lat, _, _, n_dp_results, _ = eval_result
             seen.add(n_name)
+            n_val = self._primary_value(n_acc, n_dp_results)
 
-            if n_acc > best_n_acc + tol:
-                best_neighbor, best_n_acc, best_n_lat = neighbor, n_acc, n_lat
-            elif abs(n_acc - best_n_acc) <= tol and n_lat < best_n_lat:
-                best_neighbor, best_n_acc, best_n_lat = neighbor, n_acc, n_lat
+            if n_val > best_n_val + tol:
+                best_neighbor, best_n_val, best_n_lat = neighbor, n_val, n_lat
+            elif abs(n_val - best_n_val) <= tol and n_lat < best_n_lat:
+                best_neighbor, best_n_val, best_n_lat = neighbor, n_val, n_lat
 
         if best_neighbor is None or (
-            best_n_acc < current_accuracy - tol
+            best_n_val < current_value - tol
             or (
-                abs(best_n_acc - current_accuracy) <= tol
+                abs(best_n_val - current_value) <= tol
                 and best_n_lat >= current_latency
             )
         ):
@@ -221,21 +253,34 @@ class HillClimbingModelSelector(BaseModelSelector):
         self,
         all_results: List[ModelResult],
         global_best_combo: Optional[Dict[str, ModelCandidate]],
-        global_best_accuracy: float,
+        global_best_value: float,
     ) -> SelectionResults:
-        """Mark best result and return SelectionResults."""
-        tol = 1e-9
-        if global_best_combo is not None:
-            best_name = self._combo_name(global_best_combo)
-            for result in all_results:
-                if (
-                    result.model_name == best_name
-                    and abs(result.accuracy - global_best_accuracy) < tol
-                ):
-                    result.is_best = True
-                    break
-        else:
+        """Finalize combined objectives, mark the best result, return results."""
+        self._finalize_combined_objectives(all_results)
+        if global_best_combo is None:
             print("\nNo combinations succeeded\n")
+            return SelectionResults(results=all_results)
+
+        # Prefer the combined-objective-aware _find_best when lambdas are set;
+        # otherwise honor the within-search global best to preserve the
+        # original tie-breaking semantics.
+        if self._has_combined_objective:
+            best_info = self._find_best(all_results)
+            best_name = best_info[0] if best_info else self._combo_name(global_best_combo)
+        else:
+            best_name = self._combo_name(global_best_combo)
+
+        tol = 1e-9
+        for result in all_results:
+            if result.model_name != best_name:
+                continue
+            if self._has_combined_objective:
+                result.is_best = True
+                break
+            # Accuracy-mode: match by name AND the tracked best value.
+            if abs(result.accuracy - global_best_value) < tol:
+                result.is_best = True
+                break
         return SelectionResults(results=all_results)
 
     # ------------------------------------------------------------------
@@ -251,7 +296,7 @@ class HillClimbingModelSelector(BaseModelSelector):
 
         results: List[ModelResult] = []
         best_combo = dict(combo)
-        best_accuracy = float("-inf")
+        best_value = float("-inf")
         best_latency = float("inf")
         tol = 1e-9
         no_improve_count = 0
@@ -284,13 +329,14 @@ class HillClimbingModelSelector(BaseModelSelector):
             print(f"  Iter {iteration + 1}: {result}{suffix}")
             results.append(result)
 
+            current_value = self._primary_value(accuracy, dp_results)
             should_update = (
-                best_accuracy == float("-inf")
-                or accuracy > best_accuracy + tol
-                or (abs(accuracy - best_accuracy) <= tol and latency < best_latency)
+                best_value == float("-inf")
+                or current_value > best_value + tol
+                or (abs(current_value - best_value) <= tol and latency < best_latency)
             )
             if should_update:
-                best_accuracy, best_latency, best_combo = accuracy, latency, dict(combo)
+                best_value, best_latency, best_combo = current_value, latency, dict(combo)
                 no_improve_count = 0
             else:
                 no_improve_count += 1
@@ -309,7 +355,7 @@ class HillClimbingModelSelector(BaseModelSelector):
 
             eval_results = [self._evaluate_cached(n) for n in neighbors]
             best_neighbor = self._pick_best_neighbor(
-                eval_results, neighbors, seen, accuracy, latency, tol
+                eval_results, neighbors, seen, current_value, latency, tol
             )
             if best_neighbor is None:
                 print(
@@ -320,7 +366,7 @@ class HillClimbingModelSelector(BaseModelSelector):
 
             combo = dict(best_neighbor)
 
-        return best_combo, best_accuracy, best_latency, results
+        return best_combo, best_value, best_latency, results
 
     # ------------------------------------------------------------------
     # Single restart (async)
@@ -335,7 +381,7 @@ class HillClimbingModelSelector(BaseModelSelector):
 
         results: List[ModelResult] = []
         best_combo = dict(combo)
-        best_accuracy = float("-inf")
+        best_value = float("-inf")
         best_latency = float("inf")
         tol = 1e-9
         no_improve_count = 0
@@ -368,13 +414,14 @@ class HillClimbingModelSelector(BaseModelSelector):
             print(f"  Iter {iteration + 1}: {result}{suffix}")
             results.append(result)
 
+            current_value = self._primary_value(accuracy, dp_results)
             should_update = (
-                best_accuracy == float("-inf")
-                or accuracy > best_accuracy + tol
-                or (abs(accuracy - best_accuracy) <= tol and latency < best_latency)
+                best_value == float("-inf")
+                or current_value > best_value + tol
+                or (abs(current_value - best_value) <= tol and latency < best_latency)
             )
             if should_update:
-                best_accuracy, best_latency, best_combo = accuracy, latency, dict(combo)
+                best_value, best_latency, best_combo = current_value, latency, dict(combo)
                 no_improve_count = 0
             else:
                 no_improve_count += 1
@@ -409,7 +456,7 @@ class HillClimbingModelSelector(BaseModelSelector):
                 *(_eval_neighbor_throttled(n) for n in neighbors)
             )
             best_neighbor = self._pick_best_neighbor(
-                eval_results, neighbors, seen, accuracy, latency, tol
+                eval_results, neighbors, seen, current_value, latency, tol
             )
             if best_neighbor is None:
                 print(
@@ -420,7 +467,7 @@ class HillClimbingModelSelector(BaseModelSelector):
 
             combo = dict(best_neighbor)
 
-        return best_combo, best_accuracy, best_latency, results
+        return best_combo, best_value, best_latency, results
 
     # ------------------------------------------------------------------
     # Public API
@@ -436,7 +483,7 @@ class HillClimbingModelSelector(BaseModelSelector):
     def _run_selection_sequential(self) -> SelectionResults:
         all_results: List[ModelResult] = []
         global_best_combo: Optional[Dict[str, ModelCandidate]] = None
-        global_best_accuracy = float("-inf")
+        global_best_value = float("-inf")
         global_best_latency = float("inf")
         tol = 1e-9
 
@@ -454,27 +501,27 @@ class HillClimbingModelSelector(BaseModelSelector):
             if result is None:
                 print("  All combinations exhausted. Stopping.\n")
                 break
-            best_combo, best_acc, best_lat, run_results = result
+            best_combo, best_val, best_lat, run_results = result
             all_results.extend(run_results)
 
             if (
                 global_best_combo is None
-                or best_acc > global_best_accuracy + tol
+                or best_val > global_best_value + tol
                 or (
-                    abs(best_acc - global_best_accuracy) <= tol
+                    abs(best_val - global_best_value) <= tol
                     and best_lat < global_best_latency
                 )
             ):
-                global_best_accuracy = best_acc
+                global_best_value = best_val
                 global_best_latency = best_lat
                 global_best_combo = best_combo
 
-        return self._hc_finalize(all_results, global_best_combo, global_best_accuracy)
+        return self._hc_finalize(all_results, global_best_combo, global_best_value)
 
     async def _run_selection_async(self, max_concurrent: int = 20,) -> SelectionResults:
         all_results: List[ModelResult] = []
         global_best_combo: Optional[Dict[str, ModelCandidate]] = None
-        global_best_accuracy = float("-inf")
+        global_best_value = float("-inf")
         global_best_latency = float("inf")
         tol = 1e-9
 
@@ -494,19 +541,19 @@ class HillClimbingModelSelector(BaseModelSelector):
             if result is None:
                 print("  All combinations exhausted. Stopping.\n")
                 break
-            best_combo, best_acc, best_lat, run_results = result
+            best_combo, best_val, best_lat, run_results = result
             all_results.extend(run_results)
 
             if (
                 global_best_combo is None
-                or best_acc > global_best_accuracy + tol
+                or best_val > global_best_value + tol
                 or (
-                    abs(best_acc - global_best_accuracy) <= tol
+                    abs(best_val - global_best_value) <= tol
                     and best_lat < global_best_latency
                 )
             ):
-                global_best_accuracy = best_acc
+                global_best_value = best_val
                 global_best_latency = best_lat
                 global_best_combo = best_combo
 
-        return self._hc_finalize(all_results, global_best_combo, global_best_accuracy)
+        return self._hc_finalize(all_results, global_best_combo, global_best_value)

--- a/src/agentopt/model_selection/lm_proposal.py
+++ b/src/agentopt/model_selection/lm_proposal.py
@@ -48,6 +48,8 @@ class LMProposalModelSelector(BaseModelSelector):
         dataset_preview_size: int = 10,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         node_descriptions: Optional[Dict[str, str]] = None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -56,6 +58,8 @@ class LMProposalModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             node_descriptions=node_descriptions,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         if dataset_preview_size < 1:
             raise ValueError("dataset_preview_size must be >= 1.")
@@ -111,20 +115,8 @@ class LMProposalModelSelector(BaseModelSelector):
             scores, latencies, dp_ids = self._evaluate_combo(
                 combo, self.dataset, label=combo_name
             )
-            input_tokens, output_tokens = self._fetch_tokens(combo_name)
-            accuracy, _ = self._compute_stats(scores)
-            latency = sum(latencies) / len(latencies) if latencies else 0.0
-            dp_results = self._build_datapoint_results(scores, latencies, dp_ids)
-
-            result = self._make_result(
-                model_name=combo_name,
-                accuracy=accuracy,
-                latency_seconds=latency,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                attribute="combination",
-                is_best=True,
-                datapoint_results=dp_results,
+            result = self._build_combo_result(
+                combo_name, scores, latencies, dp_ids, is_best=True,
             )
             print(f"  {result}")
         except Exception as e:
@@ -139,7 +131,9 @@ class LMProposalModelSelector(BaseModelSelector):
                 is_best=True,
             )
 
-        return SelectionResults(results=[result])
+        results = [result]
+        self._finalize_combined_objectives(results)
+        return SelectionResults(results=results)
 
     # ------------------------------------------------------------------
     # Prompt construction

--- a/src/agentopt/model_selection/matrix_ucb.py
+++ b/src/agentopt/model_selection/matrix_ucb.py
@@ -31,6 +31,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
 from ..base_models import Dataset, EvalFn, ModelCandidate
+from ..model_price import compute_price
 from .base import BaseModelSelector, ModelResult, SelectionResults
 
 logger = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ def _ucb_plain_next_batch(
 def _build_selection_results(
     selector: BaseModelSelector,
     all_combos: List[Dict[str, ModelCandidate]],
-    cell_data: Dict[Tuple[int, int], Tuple[float, float, str]],
+    cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]],
     n_datapoints: int,
 ) -> SelectionResults:
     all_results: List[ModelResult] = []
@@ -115,37 +116,35 @@ def _build_selection_results(
         combo_name = selector._combo_name(combo)
         scores: List[float] = []
         latencies: List[float] = []
+        costs: List[Optional[float]] = []
         dp_ids: List[str] = []
         for datapoint_idx in range(n_datapoints):
             t = cell_data.get((combo_idx, datapoint_idx))
             if t:
                 scores.append(t[0])
                 latencies.append(t[1])
-                dp_ids.append(t[2])
+                costs.append(t[2])
+                dp_ids.append(t[3])
         if scores:
-            accuracy = sum(scores) / len(scores)
-            avg_latency = sum(latencies) / len(latencies)
-        else:
-            accuracy, avg_latency = 0.0, 0.0
-        input_tokens, output_tokens = selector._fetch_tokens(combo_name)
-        dp_results = (
-            selector._build_datapoint_results(scores, latencies, dp_ids)
-            if dp_ids
-            else []
-        )
-        all_results.append(
-            selector._make_result(
-                model_name=combo_name,
-                accuracy=accuracy,
-                latency_seconds=avg_latency,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                attribute="combination",
-                is_best=False,
-                datapoint_results=dp_results,
+            all_results.append(
+                selector._build_combo_result(
+                    combo_name, scores, latencies, dp_ids, costs=costs,
+                )
             )
-        )
+        else:
+            all_results.append(
+                selector._make_result(
+                    model_name=combo_name,
+                    accuracy=0.0,
+                    latency_seconds=0.0,
+                    input_tokens={},
+                    output_tokens={},
+                    attribute="combination",
+                    is_best=False,
+                )
+            )
 
+    selector._finalize_combined_objectives(all_results)
     best_info = selector._find_best(all_results)
     if best_info is not None:
         best_name, _ = best_info
@@ -160,21 +159,59 @@ def _build_selection_results(
 
 
 def _record_cells(
-    cell_data: Dict[Tuple[int, int], Tuple[float, float, str]],
+    cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]],
     combo_idx: int,
     datapoint_idx: int,
     scores: List[float],
     latencies: List[float],
+    costs: List[Optional[float]],
     dp_ids: List[str],
 ) -> None:
     if not scores:
         cell_data[(combo_idx, datapoint_idx)] = (
             0.0,
             0.0,
+            None,
             f"missing::{combo_idx}:{datapoint_idx}",
         )
         return
-    cell_data[(combo_idx, datapoint_idx)] = (scores[0], latencies[0], dp_ids[0])
+    cost = costs[0] if costs else None
+    cell_data[(combo_idx, datapoint_idx)] = (
+        scores[0], latencies[0], cost, dp_ids[0],
+    )
+
+
+def _refresh_observed_np(
+    selector: BaseModelSelector,
+    observed: np.ndarray,
+    cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]],
+) -> None:
+    """Rewrite ``observed`` from ``cell_data`` against the selector's current normalizer.
+
+    Called after absorbing new observations so plain-UCB row means use the
+    latest combined objective rather than stale values. No-op (preserves prior
+    contents) when no lambdas are configured.
+    """
+    if not selector._has_combined_objective:
+        return
+    for (ci, di), (sc, lat, cost, dp_id) in cell_data.items():
+        if dp_id.startswith("missing::"):
+            continue
+        observed[ci, di] = selector._combined_objective(sc, lat, cost)
+
+
+def _refresh_observed_t(
+    selector: BaseModelSelector,
+    observed_t: "torch.Tensor",
+    cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]],
+) -> None:
+    """Torch counterpart of :func:`_refresh_observed_np` for the LRF variant."""
+    if not selector._has_combined_objective:
+        return
+    for (ci, di), (sc, lat, cost, dp_id) in cell_data.items():
+        if dp_id.startswith("missing::"):
+            continue
+        observed_t[ci, di] = float(selector._combined_objective(sc, lat, cost))
 
 
 class MatrixUCBModelSelector(BaseModelSelector):
@@ -202,6 +239,8 @@ class MatrixUCBModelSelector(BaseModelSelector):
         seed: Optional[int] = None,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -210,6 +249,8 @@ class MatrixUCBModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         self.a = float(a)
         self.observation_budget_fraction = _resolve_observation_budget_fraction(
@@ -239,7 +280,7 @@ class MatrixUCBModelSelector(BaseModelSelector):
         n_datapoints = len(dataset_list)
         n_combos = len(all_combos)
         observed = np.full((n_combos, n_datapoints), np.nan, dtype=np.float64)
-        cell_data: Dict[Tuple[int, int], Tuple[float, float, str]] = {}
+        cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]] = {}
         mc = max(max_concurrent, 1)
         target_n = _target_observation_count(
             n_combos, n_datapoints, self.observation_budget_fraction,
@@ -305,9 +346,13 @@ class MatrixUCBModelSelector(BaseModelSelector):
                     logger.warning("Matrix UCB async cell error: %s", res)
                     continue
                 combo_i, dp_i, sc, lat, ids = res
-                _record_cells(cell_data, combo_i, dp_i, sc, lat, ids)
+                costs = self._observe_combo(sc, lat, ids) if sc else []
+                _record_cells(cell_data, combo_i, dp_i, sc, lat, costs, ids)
                 if sc:
-                    observed[combo_i, dp_i] = sc[0]
+                    observed[combo_i, dp_i] = self._combined_objective(
+                        sc[0], lat[0], costs[0],
+                    )
+            _refresh_observed_np(self, observed, cell_data)
 
         return _build_selection_results(self, all_combos, cell_data, n_datapoints)
 
@@ -342,6 +387,8 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
         seed: Optional[int] = None,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         try:
             import torch  # noqa: F401
@@ -367,6 +414,8 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         self.Factorization = Factorization
         self.rank = int(rank)
@@ -475,7 +524,7 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
             device=self.device,
             dtype=torch.float64,
         )
-        cell_data: Dict[Tuple[int, int], Tuple[float, float, str]] = {}
+        cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]] = {}
         mc = max(max_concurrent, 1)
         target_n = _target_observation_count(
             n_combos, n_datapoints, self.observation_budget_fraction,
@@ -519,9 +568,15 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
                 sc, lat, ids = self._evaluate_combo(
                     combo, [dataset_list[int(dp_i)]], label=name, dp_offset=int(dp_i),
                 )
-                _record_cells(cell_data, int(combo_i), int(dp_i), sc, lat, ids)
+                costs = self._observe_combo(sc, lat, ids) if sc else []
+                _record_cells(
+                    cell_data, int(combo_i), int(dp_i), sc, lat, costs, ids,
+                )
                 if sc:
-                    observed_t[int(combo_i), int(dp_i)] = float(sc[0])
+                    observed_t[int(combo_i), int(dp_i)] = float(
+                        self._combined_objective(sc[0], lat[0], costs[0])
+                    )
+            _refresh_observed_t(self, observed_t, cell_data)
 
         return _build_selection_results(self, all_combos, cell_data, n_datapoints)
 
@@ -547,7 +602,7 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
             device=self.device,
             dtype=torch.float64,
         )
-        cell_data: Dict[Tuple[int, int], Tuple[float, float, str]] = {}
+        cell_data: Dict[Tuple[int, int], Tuple[float, float, Optional[float], str]] = {}
         mc = max(max_concurrent, 1)
         target_n = _target_observation_count(
             n_combos, n_datapoints, self.observation_budget_fraction,
@@ -613,8 +668,12 @@ class MatrixUCBLRFModelSelector(BaseModelSelector):
                     logger.warning("Matrix UCB-LRF async cell error: %s", res)
                     continue
                 combo_i, dp_i, sc, lat, ids = res
-                _record_cells(cell_data, combo_i, dp_i, sc, lat, ids)
+                costs = self._observe_combo(sc, lat, ids) if sc else []
+                _record_cells(cell_data, combo_i, dp_i, sc, lat, costs, ids)
                 if sc:
-                    observed_t[combo_i, dp_i] = float(sc[0])
+                    observed_t[combo_i, dp_i] = float(
+                        self._combined_objective(sc[0], lat[0], costs[0])
+                    )
+            _refresh_observed_t(self, observed_t, cell_data)
 
         return _build_selection_results(self, all_combos, cell_data, n_datapoints)

--- a/src/agentopt/model_selection/matrix_ucb.py
+++ b/src/agentopt/model_selection/matrix_ucb.py
@@ -31,7 +31,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
 from ..base_models import Dataset, EvalFn, ModelCandidate
-from ..model_price import compute_price
 from .base import BaseModelSelector, ModelResult, SelectionResults
 
 logger = logging.getLogger(__name__)

--- a/src/agentopt/model_selection/random_search.py
+++ b/src/agentopt/model_selection/random_search.py
@@ -30,6 +30,8 @@ class RandomSearchModelSelector(BaseModelSelector):
         seed: Optional[int] = None,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -38,6 +40,8 @@ class RandomSearchModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         if not 0 < sample_fraction <= 1:
             raise ValueError("sample_fraction must be in the range (0, 1].")
@@ -72,10 +76,6 @@ class RandomSearchModelSelector(BaseModelSelector):
         all_combos, sampled = self._get_sampled_combinations()
 
         all_results: List[ModelResult] = []
-        best_combo_name = None
-        best_accuracy = float("-inf")
-        best_latency = float("inf")
-        tol = 1e-9
 
         print(f"\n{'='*60}")
         print(
@@ -93,30 +93,11 @@ class RandomSearchModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = self._evaluate_combo(
                     combo, self.dataset, label=combo_name
                 )
-                input_tokens, output_tokens = self._fetch_tokens(combo_name)
-                accuracy, _ = self._compute_stats(scores)
-                latency = sum(latencies) / len(latencies) if latencies else 0.0
-                dp_results = self._build_datapoint_results(scores, latencies, dp_ids)
-
-                result = self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                result = self._build_combo_result(
+                    combo_name, scores, latencies, dp_ids,
                 )
                 print(f"  {result}")
                 all_results.append(result)
-
-                if (accuracy > best_accuracy + tol) or (
-                    abs(accuracy - best_accuracy) <= tol and latency < best_latency
-                ):
-                    best_accuracy = accuracy
-                    best_latency = latency
-                    best_combo_name = combo_name
 
             except Exception as e:
                 print(f"  [{combo_name}] failed: {e}")
@@ -132,9 +113,12 @@ class RandomSearchModelSelector(BaseModelSelector):
                     )
                 )
 
-        if best_combo_name is not None:
+        self._finalize_combined_objectives(all_results)
+        best_info = self._find_best(all_results)
+        if best_info is not None:
+            best_name, _ = best_info
             for result in all_results:
-                if result.model_name == best_combo_name:
+                if result.model_name == best_name:
                     result.is_best = True
                     break
         else:
@@ -168,19 +152,8 @@ class RandomSearchModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = await self._evaluate_combo_async(
                     combo, self.dataset, label=combo_name, max_concurrent=dp_concurrent
                 )
-                input_tokens, output_tokens = self._fetch_tokens(combo_name)
-                accuracy, _ = self._compute_stats(scores)
-                latency = sum(latencies) / len(latencies) if latencies else 0.0
-                dp_results = self._build_datapoint_results(scores, latencies, dp_ids)
-                result = self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                result = self._build_combo_result(
+                    combo_name, scores, latencies, dp_ids,
                 )
                 print(f"  {result}")
                 return combo_name, result
@@ -209,6 +182,7 @@ class RandomSearchModelSelector(BaseModelSelector):
                 _, result = res
                 all_results.append(result)
 
+        self._finalize_combined_objectives(all_results)
         best_info = self._find_best(all_results)
         if best_info is not None:
             best_name, _ = best_info

--- a/src/agentopt/model_selection/threshold_successive_elimination.py
+++ b/src/agentopt/model_selection/threshold_successive_elimination.py
@@ -29,6 +29,8 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
         confidence: float = 1.0,
         model_prices: Optional[Dict[str, Dict[str, float]]] = None,
         tracker=None,
+        lambda_cost: float = 0.0,
+        lambda_latency: float = 0.0,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -37,6 +39,8 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             dataset=dataset,
             model_prices=model_prices,
             tracker=tracker,
+            lambda_cost=lambda_cost,
+            lambda_latency=lambda_latency,
         )
         n = len(self.dataset)
         if n_initial is None:
@@ -53,6 +57,17 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             return asyncio.run(self._select_async(max_concurrent))
         return self._select_sequential()
 
+    def _arm_objectives(
+        self,
+        idx: int,
+        combo_scores: Dict[int, List[float]],
+        combo_latencies: Dict[int, List[float]],
+        combo_costs: Dict[int, List[Optional[float]]],
+    ) -> List[float]:
+        return self._compute_objectives(
+            combo_scores[idx], combo_latencies[idx], combo_costs[idx]
+        )
+
     def _select_sequential(self) -> SelectionResults:
         all_combos = self._all_combos()
         dataset_list = list(self.dataset)
@@ -60,6 +75,9 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(len(all_combos))}
         combo_latencies: Dict[int, List[float]] = {
+            i: [] for i in range(len(all_combos))
+        }
+        combo_costs: Dict[int, List[Optional[float]]] = {
             i: [] for i in range(len(all_combos))
         }
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(len(all_combos))}
@@ -86,13 +104,18 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             scores, latencies, dp_ids = self._evaluate_combo(
                 combo, init_batch, label=combo_name, dp_offset=offset
             )
+            costs = self._observe_combo(scores, latencies, dp_ids)
             combo_scores[idx].extend(scores)
             combo_latencies[idx].extend(latencies)
+            combo_costs[idx].extend(costs)
             combo_dp_ids[idx].extend(dp_ids)
-            mu, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+            objs = self._arm_objectives(
+                idx, combo_scores, combo_latencies, combo_costs
+            )
+            mu, lcb, ucb = self._confidence_bounds(objs)
             print(
                 f"  {combo_name}: mu={mu:.3f}, [{lcb:.3f}, {ucb:.3f}] "
-                f"(n={len(combo_scores[idx])})"
+                f"(n={len(objs)})"
             )
         offset += init_batch_size
 
@@ -113,18 +136,26 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
                 scores, latencies, dp_ids = self._evaluate_combo(
                     combo, batch, label=combo_name, dp_offset=offset - 1
                 )
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                objs = self._arm_objectives(
+                    idx, combo_scores, combo_latencies, combo_costs
+                )
+                mu, lcb, ucb = self._confidence_bounds(objs)
                 print(
                     f"  {combo_name}: mu={mu:.3f}, [{lcb:.3f}, {ucb:.3f}] "
-                    f"(n={len(combo_scores[idx])})"
+                    f"(n={len(objs)})"
                 )
 
             newly_eliminated: Set[int] = set()
             for idx in active:
-                _, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                objs = self._arm_objectives(
+                    idx, combo_scores, combo_latencies, combo_costs
+                )
+                _, lcb, ucb = self._confidence_bounds(objs)
                 # Classified wrt threshold, so this arm is no longer ambiguous.
                 if ucb < self.threshold or lcb > self.threshold:
                     newly_eliminated.add(idx)
@@ -132,7 +163,10 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             if newly_eliminated:
                 for idx in sorted(newly_eliminated):
                     combo_name = self._combo_name(all_combos[idx])
-                    _, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                    objs = self._arm_objectives(
+                        idx, combo_scores, combo_latencies, combo_costs
+                    )
+                    _, lcb, ucb = self._confidence_bounds(objs)
                     side = "below" if ucb < self.threshold else "above"
                     print(
                         f"  Eliminated: {combo_name} "
@@ -152,7 +186,7 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             round_num += 1
 
         return self._build_results(
-            all_combos, combo_scores, combo_latencies, combo_dp_ids
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
         )
 
     async def _select_async(self, max_concurrent: int = 20) -> SelectionResults:
@@ -162,6 +196,9 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
 
         combo_scores: Dict[int, List[float]] = {i: [] for i in range(len(all_combos))}
         combo_latencies: Dict[int, List[float]] = {
+            i: [] for i in range(len(all_combos))
+        }
+        combo_costs: Dict[int, List[Optional[float]]] = {
             i: [] for i in range(len(all_combos))
         }
         combo_dp_ids: Dict[int, List[str]] = {i: [] for i in range(len(all_combos))}
@@ -212,14 +249,19 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
                 logger.warning("Initial batch evaluation error: %s", res)
                 continue
             idx, scores, latencies, dp_ids = res
+            costs = self._observe_combo(scores, latencies, dp_ids)
             combo_scores[idx].extend(scores)
             combo_latencies[idx].extend(latencies)
+            combo_costs[idx].extend(costs)
             combo_dp_ids[idx].extend(dp_ids)
-            mu, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+            objs = self._arm_objectives(
+                idx, combo_scores, combo_latencies, combo_costs
+            )
+            mu, lcb, ucb = self._confidence_bounds(objs)
             print(
                 f"  {self._combo_name(all_combos[idx])}: "
                 f"mu={mu:.3f}, [{lcb:.3f}, {ucb:.3f}] "
-                f"(n={len(combo_scores[idx])})"
+                f"(n={len(objs)})"
             )
         offset += init_batch_size
 
@@ -263,26 +305,37 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
                     logger.warning("Batch evaluation error: %s", res)
                     continue
                 idx, scores, latencies, dp_ids = res
+                costs = self._observe_combo(scores, latencies, dp_ids)
                 combo_scores[idx].extend(scores)
                 combo_latencies[idx].extend(latencies)
+                combo_costs[idx].extend(costs)
                 combo_dp_ids[idx].extend(dp_ids)
-                mu, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                objs = self._arm_objectives(
+                    idx, combo_scores, combo_latencies, combo_costs
+                )
+                mu, lcb, ucb = self._confidence_bounds(objs)
                 print(
                     f"  {self._combo_name(all_combos[idx])}: "
                     f"mu={mu:.3f}, [{lcb:.3f}, {ucb:.3f}] "
-                    f"(n={len(combo_scores[idx])})"
+                    f"(n={len(objs)})"
                 )
 
             newly_eliminated: Set[int] = set()
             for idx in active:
-                _, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                objs = self._arm_objectives(
+                    idx, combo_scores, combo_latencies, combo_costs
+                )
+                _, lcb, ucb = self._confidence_bounds(objs)
                 if ucb < self.threshold or lcb > self.threshold:
                     newly_eliminated.add(idx)
 
             if newly_eliminated:
                 for idx in sorted(newly_eliminated):
                     combo_name = self._combo_name(all_combos[idx])
-                    _, lcb, ucb = self._confidence_bounds(combo_scores[idx])
+                    objs = self._arm_objectives(
+                        idx, combo_scores, combo_latencies, combo_costs
+                    )
+                    _, lcb, ucb = self._confidence_bounds(objs)
                     side = "below" if ucb < self.threshold else "above"
                     print(
                         f"  Eliminated: {combo_name} "
@@ -302,14 +355,14 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
             round_num += 1
 
         return self._build_results(
-            all_combos, combo_scores, combo_latencies, combo_dp_ids
+            all_combos, combo_scores, combo_latencies, combo_costs, combo_dp_ids
         )
 
-    def _confidence_bounds(self, scores: List[float]) -> Tuple[float, float, float]:
-        n = len(scores)
+    def _confidence_bounds(self, values: List[float]) -> Tuple[float, float, float]:
+        n = len(values)
         if n == 0:
             return 0.0, float("-inf"), float("inf")
-        mu, std = self._compute_stats(scores)
+        mu, std = self._compute_stats(values)
         se = std / math.sqrt(n)
         radius = self.confidence * se
         return mu, mu - radius, mu + radius
@@ -319,38 +372,37 @@ class ThresholdBanditSEModelSelector(BaseModelSelector):
         all_combos: List[Dict[str, ModelCandidate]],
         combo_scores: Dict[int, List[float]],
         combo_latencies: Dict[int, List[float]],
+        combo_costs: Dict[int, List[Optional[float]]],
         combo_dp_ids: Dict[int, List[str]],
     ) -> SelectionResults:
         all_results: List[ModelResult] = []
         for idx, combo in enumerate(all_combos):
             combo_name = self._combo_name(combo)
             scores = combo_scores[idx]
-            latencies = combo_latencies[idx]
-            dp_ids = combo_dp_ids[idx]
             if scores:
-                accuracy = sum(scores) / len(scores)
-                avg_latency = sum(latencies) / len(latencies)
-            else:
-                accuracy, avg_latency = 0.0, 0.0
-            input_tokens, output_tokens = self._fetch_tokens(combo_name)
-            dp_results = (
-                self._build_datapoint_results(scores, latencies, dp_ids)
-                if dp_ids
-                else []
-            )
-            all_results.append(
-                self._make_result(
-                    model_name=combo_name,
-                    accuracy=accuracy,
-                    latency_seconds=avg_latency,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    attribute="combination",
-                    is_best=False,
-                    datapoint_results=dp_results,
+                all_results.append(
+                    self._build_combo_result(
+                        combo_name,
+                        scores,
+                        combo_latencies[idx],
+                        combo_dp_ids[idx],
+                        costs=combo_costs[idx],
+                    )
                 )
-            )
+            else:
+                all_results.append(
+                    self._make_result(
+                        model_name=combo_name,
+                        accuracy=0.0,
+                        latency_seconds=0.0,
+                        input_tokens={},
+                        output_tokens={},
+                        attribute="combination",
+                        is_best=False,
+                    )
+                )
 
+        self._finalize_combined_objectives(all_results)
         best_info = self._find_best(all_results)
         if best_info is not None:
             best_name, _ = best_info

--- a/tests/test_combined_objective.py
+++ b/tests/test_combined_objective.py
@@ -1,0 +1,307 @@
+"""Tests for the combined objective (accuracy / latency / cost weighting).
+
+Covers:
+- The math helpers on BaseModelSelector (_minmax_norm, _combined_objective,
+  adaptive normalizer state, batch + mean helpers, _absorb_observations).
+- _find_best falling back to accuracy when combined_objective is unset, and
+  preferring combined_objective when it is set on any result.
+- _finalize_combined_objectives recomputing per-result objectives against the
+  final normalizer state (idempotent under repeated calls).
+- End-to-end brute_force run with lambda_latency > 0 picking a faster combo
+  over a more accurate slow one.
+"""
+
+import time
+
+import pytest
+
+from agentopt.model_selection import BruteForceModelSelector
+from agentopt.model_selection.base import (
+    DatapointResult,
+    ModelResult,
+    SelectionResults,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _NoopAgent:
+    """Minimal agent stub that satisfies the BaseModelSelector contract.
+
+    The end-to-end test below overrides this with a per-model behavior agent.
+    """
+
+    def __init__(self, models):
+        self.models = models
+
+    def run(self, input_data):
+        return "ok"
+
+
+def _eval_fn(expected, actual):
+    return 1.0 if str(expected).lower() in str(actual).lower() else 0.0
+
+
+def _selector(lambda_cost: float = 0.0, lambda_latency: float = 0.0):
+    """Build a BruteForceModelSelector with stub agent/eval/dataset.
+
+    Used to access the BaseModelSelector helper methods under test.
+    """
+    return BruteForceModelSelector(
+        agent=_NoopAgent,
+        models={"node": ["m"]},
+        eval_fn=_eval_fn,
+        dataset=[("x", "ok")],
+        lambda_cost=lambda_cost,
+        lambda_latency=lambda_latency,
+    )
+
+
+def _dp(idx: int, score: float, latency: float) -> DatapointResult:
+    return DatapointResult(
+        datapoint_index=idx,
+        score=score,
+        latency_seconds=latency,
+        input_tokens={},
+        output_tokens={},
+    )
+
+
+def _result(name: str, accuracy: float, latency: float, dps=None, *, combined=None):
+    return ModelResult(
+        model_name=name,
+        accuracy=accuracy,
+        latency_seconds=latency,
+        input_tokens={},
+        output_tokens={},
+        attribute="combination",
+        is_best=False,
+        datapoint_results=dps or [],
+        combined_objective=combined,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Math helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMinMaxNorm:
+    def test_zero_when_range_degenerate(self):
+        assert BruteForceModelSelector._minmax_norm(5.0, 1.0, 1.0) == 0.0
+
+    def test_zero_when_lo_or_hi_infinite(self):
+        assert BruteForceModelSelector._minmax_norm(0.5, float("inf"), 1.0) == 0.0
+        assert BruteForceModelSelector._minmax_norm(0.5, 0.0, float("inf")) == 0.0
+
+    def test_zero_when_value_none_or_nan(self):
+        assert BruteForceModelSelector._minmax_norm(None, 0.0, 1.0) == 0.0
+        assert BruteForceModelSelector._minmax_norm(float("nan"), 0.0, 1.0) == 0.0
+
+    def test_linear_scaling(self):
+        # 0.25 of the way from 1 to 5 → 0.25
+        assert BruteForceModelSelector._minmax_norm(2.0, 1.0, 5.0) == pytest.approx(0.25)
+
+
+class TestCombinedObjectiveZeroLambdas:
+    """When both lambdas are zero, behaviour must match raw accuracy."""
+
+    def test_returns_score_unchanged(self):
+        sel = _selector(0.0, 0.0)
+        assert sel._combined_objective(0.42, 100.0, 5.0) == 0.42
+
+    def test_has_combined_objective_false(self):
+        assert _selector(0.0, 0.0)._has_combined_objective is False
+        assert _selector(0.0, 0.1)._has_combined_objective is True
+        assert _selector(0.1, 0.0)._has_combined_objective is True
+
+    def test_compute_objectives_returns_score_copy(self):
+        sel = _selector(0.0, 0.0)
+        scores = [1.0, 0.0]
+        out = sel._compute_objectives(scores, [10.0, 1.0], [0.5, 0.01])
+        assert out == scores
+        assert out is not scores  # defensive copy
+
+    def test_mean_objective_none_without_lambdas(self):
+        sel = _selector(0.0, 0.0)
+        assert sel._mean_objective([1.0, 0.0], [1.0, 1.0], [0.0, 0.0]) is None
+
+
+class TestAbsorbObservations:
+    def test_updates_running_min_max_for_lat_and_cost(self):
+        sel = _selector(lambda_latency=0.1, lambda_cost=0.1)
+        sel._absorb_observations([1.0, 5.0, 3.0], [0.001, 0.005, 0.003])
+        assert sel._latency_min == 1.0
+        assert sel._latency_max == 5.0
+        assert sel._cost_min == 0.001
+        assert sel._cost_max == 0.005
+
+    def test_noop_when_no_lambdas(self):
+        sel = _selector(0.0, 0.0)
+        sel._absorb_observations([1.0, 5.0], [0.001, 0.005])
+        # Sentinel unchanged.
+        assert sel._latency_min == float("inf")
+        assert sel._cost_max == float("-inf")
+
+    def test_skips_none_cost(self):
+        sel = _selector(lambda_cost=0.1)
+        sel._absorb_observations([1.0], [None])
+        assert sel._cost_min == float("inf")
+        assert sel._cost_max == float("-inf")
+
+
+class TestCombinedObjectiveMath:
+    def test_normalises_against_running_minmax(self):
+        sel = _selector(lambda_cost=0.5, lambda_latency=0.5)
+        # Two samples: cost ∈ {0.001, 0.005}, latency ∈ {1, 5}.
+        sel._absorb_observations([1.0, 5.0], [0.001, 0.005])
+        # Mid-point sample (cost halfway, latency halfway, score 1.0):
+        #   norm_cost = 0.5, norm_lat = 0.5
+        #   obj = 1.0 - 0.5 * 0.5 - 0.5 * 0.5 = 0.5
+        assert sel._combined_objective(1.0, 3.0, 0.003) == pytest.approx(0.5)
+
+    def test_min_cell_drops_penalties_to_zero(self):
+        sel = _selector(lambda_cost=1.0, lambda_latency=1.0)
+        sel._absorb_observations([1.0, 5.0], [0.001, 0.005])
+        # At the min, both norm terms are 0 → obj == score.
+        assert sel._combined_objective(0.8, 1.0, 0.001) == pytest.approx(0.8)
+
+    def test_max_cell_subtracts_full_lambdas(self):
+        sel = _selector(lambda_cost=0.3, lambda_latency=0.2)
+        sel._absorb_observations([1.0, 5.0], [0.001, 0.005])
+        # norm_cost = norm_lat = 1.0 → obj = score - 0.3 - 0.2
+        assert sel._combined_objective(1.0, 5.0, 0.005) == pytest.approx(0.5)
+
+    def test_mean_objective_matches_per_sample_mean(self):
+        sel = _selector(lambda_latency=0.5)
+        sel._absorb_observations([1.0, 5.0], [None, None])
+        # Two samples at the latency extremes: norm_lat = 0 and 1.
+        # obj0 = 1.0 - 0.5 * 0 = 1.0; obj1 = 0.5 - 0.5 * 1 = 0.0
+        # mean = 0.5
+        assert sel._mean_objective(
+            [1.0, 0.5], [1.0, 5.0], [None, None]
+        ) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# _find_best
+# ---------------------------------------------------------------------------
+
+
+class TestFindBest:
+    def test_falls_back_to_accuracy_when_none_set(self):
+        a = _result("a", 0.8, 1.0)
+        b = _result("b", 0.9, 2.0)
+        assert BruteForceModelSelector._find_best([a, b]) == ("b", 0.9)
+
+    def test_prefers_combined_objective_when_any_set(self):
+        a = _result("a", 0.9, 1.0, combined=0.4)  # high accuracy, low obj (expensive)
+        b = _result("b", 0.7, 1.0, combined=0.6)  # lower accuracy, higher obj
+        name, value = BruteForceModelSelector._find_best([a, b])
+        assert name == "b"
+        assert value == pytest.approx(0.6)
+
+    def test_latency_tiebreaks_within_equal_combined(self):
+        a = _result("a", 0.5, 5.0, combined=0.5)
+        b = _result("b", 0.5, 1.0, combined=0.5)
+        assert BruteForceModelSelector._find_best([a, b])[0] == "b"
+
+    def test_returns_none_for_empty_list(self):
+        assert BruteForceModelSelector._find_best([]) is None
+
+
+# ---------------------------------------------------------------------------
+# _finalize_combined_objectives
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeCombinedObjectives:
+    def test_noop_when_no_lambdas(self):
+        sel = _selector(0.0, 0.0)
+        r = _result("a", 1.0, 1.0, [_dp(0, 1.0, 1.0)])
+        sel._finalize_combined_objectives([r])
+        assert r.combined_objective is None
+
+    def test_sets_combined_against_final_normalizer(self):
+        sel = _selector(lambda_latency=0.5)
+        # Two combos with latencies bracketing the range.
+        fast = _result("fast", 1.0, 1.0, [_dp(0, 1.0, 1.0)])
+        slow = _result("slow", 1.0, 5.0, [_dp(0, 1.0, 5.0)])
+        sel._finalize_combined_objectives([fast, slow])
+        # fast → norm_lat = 0 → obj = 1.0
+        # slow → norm_lat = 1 → obj = 0.5
+        assert fast.combined_objective == pytest.approx(1.0)
+        assert slow.combined_objective == pytest.approx(0.5)
+
+    def test_idempotent(self):
+        sel = _selector(lambda_latency=0.5)
+        r1 = _result("a", 1.0, 1.0, [_dp(0, 1.0, 1.0)])
+        r2 = _result("b", 0.8, 4.0, [_dp(0, 0.8, 4.0)])
+        sel._finalize_combined_objectives([r1, r2])
+        first = (r1.combined_objective, r2.combined_objective)
+        sel._finalize_combined_objectives([r1, r2])
+        second = (r1.combined_objective, r2.combined_objective)
+        assert first == second
+
+    def test_handles_empty_datapoint_results(self):
+        sel = _selector(lambda_latency=0.5)
+        r = _result("a", 0.0, 0.0, [])
+        sel._finalize_combined_objectives([r])
+        assert r.combined_objective is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: brute_force prefers a faster combo when lambda_latency > 0
+# ---------------------------------------------------------------------------
+
+
+class _LatencyTunedAgent:
+    """Returns the correct answer for both models, but model 'slow' sleeps."""
+
+    SLEEP_MAP = {"fast": 0.0, "slow": 0.05}
+
+    def __init__(self, models):
+        self.model_name = models["node"]
+
+    def run(self, input_data):
+        time.sleep(self.SLEEP_MAP[self.model_name])
+        return "correct"
+
+
+class TestBruteForceLatencyWeighting:
+    def test_zero_lambdas_preserves_accuracy_pick(self):
+        sel = BruteForceModelSelector(
+            agent=_LatencyTunedAgent,
+            models={"node": ["fast", "slow"]},
+            eval_fn=_eval_fn,
+            dataset=[("?", "correct"), ("?", "correct")],
+        )
+        results = sel.select_best(parallel=False)
+        best = results.get_best()
+        # Both are equally accurate; latency tiebreak picks 'fast'.
+        assert best is not None
+        assert best.model_name == "node=fast"
+        # combined_objective stays unset when no lambdas configured.
+        assert all(r.combined_objective is None for r in results.results)
+
+    def test_lambda_latency_picks_fast_when_accuracy_tied(self):
+        sel = BruteForceModelSelector(
+            agent=_LatencyTunedAgent,
+            models={"node": ["fast", "slow"]},
+            eval_fn=_eval_fn,
+            dataset=[("?", "correct"), ("?", "correct")],
+            lambda_latency=0.5,
+        )
+        results = sel.select_best(parallel=False)
+        best = results.get_best()
+        assert best is not None
+        assert best.model_name == "node=fast"
+        # combined_objective now populated on results.
+        assert all(r.combined_objective is not None for r in results.results)
+        # fast combo's objective is strictly higher than slow's.
+        fast = next(r for r in results.results if r.model_name == "node=fast")
+        slow = next(r for r in results.results if r.model_name == "node=slow")
+        assert fast.combined_objective > slow.combined_objective


### PR DESCRIPTION
Introduces `lambda_cost` and `lambda_latency` kwargs on every selector (defaults 0.0, so existing behavior is preserved). Cost and latency are adaptively min-max normalized against the running observed range, then combined with the score as `score - lambda_cost*norm_cost - lambda_latency*norm_latency`.

The combined objective is the **search-time reward** wherever a selector makes elimination, UCB, or neighbor-selection decisions — matching the offline simulator semantics in experiments/combined_objective/. A `_finalize_combined_objectives` pass recomputes per-result objectives against the final normalizer so all results rank on a consistent scale, and `_find_best` now prefers `combined_objective` when set.